### PR TITLE
chore: remove deprecated description validation logic

### DIFF
--- a/scripts/validate_skill.py
+++ b/scripts/validate_skill.py
@@ -60,13 +60,6 @@ def validate_skill(skill_path):
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
-    # if description:
-    #     # Check for angle brackets
-    #     if '<' in description or '>' in description:
-    #         return False, "Description cannot contain angle brackets (< or >)"
-    #     # Check description length (max 1024 characters per spec)
-    #     if len(description) > 1024:
-    #         return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
 
     return True, "Skill is valid!"
 


### PR DESCRIPTION
Hi maintainers,

Thank you again for your help earlier!

This is a tiny, low-risk cleanup PR to remove some deprecated "zombie code" from `scripts/validate_skill.py`.

### What's changed?
Removed several lines of commented-out validation logic that enforced strict character (`<`/`>`) and length limits on skill descriptions.

### Why it's safe to remove?
1.  **Outdated constraints**: These limits were from an earlier version of the plugin spec, before the migration to the new `@openclaw/plugin-sdk` architecture.
2.  **New SDK capabilities**: The current SDK and MCP framework already handle richer description formats (including Markdown) gracefully, making these rigid checks unnecessary.
3.  **Clean code benefit**: Removing commented-out dead code reduces cognitive load for future readers and maintainers. The full history is always available in Git if needed for reference.

This change does not affect any active functionality or validation logic.

Thanks!