### PR TITLE
Add genomic-intelligence skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![GitHub Stars](https://img.shields.io/github/stars/FreedomIntelligence/OpenClaw-Medical-Skills?style=for-the-badge&logo=github&color=gold)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/FreedomIntelligence/OpenClaw-Medical-Skills?style=for-the-badge&logo=github&color=blue)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/network/members)
 [![GitHub Issues](https://img.shields.io/github/issues/FreedomIntelligence/OpenClaw-Medical-Skills?style=for-the-badge&logo=github)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/issues)
-[![Skills Count](https://img.shields.io/badge/Skills-869-brightgreen?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyem0tMiAxNWwtNS01IDEuNDEtMS40MUwxMCAxNC4xN2w3LjU5LTcuNTlMMTkgOGwtOSA5eiIvPjwvc3ZnPg==)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/tree/main/skills)
+[![Skills Count](https://img.shields.io/badge/Skills-870-brightgreen?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyem0tMiAxNWwtNS01IDEuNDEtMS40MUwxMCAxNC4xN2w3LjU5LTcuNTlMMTkgOGwtOSA5eiIvPjwvc3ZnPg==)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/tree/main/skills)
 [![License](https://img.shields.io/badge/License-MIT-purple?style=for-the-badge)](LICENSE)
 [![Platform](https://img.shields.io/badge/Platform-OpenClaw%20%7C%20NanoClaw-orange?style=for-the-badge)](https://github.com/openclaw/openclaw)
 
 **The largest open-source medical AI skill library for OpenClaw.**
 
-*869 curated skills · Clinical · Genomics · Drug Discovery · Bioinformatics · Medical Devices*
+*870 curated skills · Clinical · Genomics · Drug Discovery · Bioinformatics · Medical Devices*
 
 [English](#) | [中文](README_zh.md)
 
@@ -21,7 +21,7 @@
 
 ## What Is This?
 
-**OpenClaw Medical Skills** is a curated collection of **869 AI agent skills** covering the full spectrum of biomedical and clinical research. These skills are designed for [OpenClaw](https://github.com/openclaw/openclaw) / [NanoClaw](https://github.com/qwibitai/nanoclaw) — Claude-based personal AI assistant frameworks — and transform a general-purpose AI agent into a powerful medical and scientific research companion.
+**OpenClaw Medical Skills** is a curated collection of **870 AI agent skills** covering the full spectrum of biomedical and clinical research. These skills are designed for [OpenClaw](https://github.com/openclaw/openclaw) / [NanoClaw](https://github.com/qwibitai/nanoclaw) — Claude-based personal AI assistant frameworks — and transform a general-purpose AI agent into a powerful medical and scientific research companion.
 
 Each skill is a self-contained module (a `SKILL.md` file) that:
 - Teaches the agent specialized domain knowledge and workflows

--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ Your agent should list the installed skills with their capabilities.
 |---|---|---|
 | General & Core | 10 | Browser/search, document tools, and developer workflow utilities |
 | Medical & Clinical | 119 | Clinical reports, CDS, oncology, imaging, and healthcare AI |
-| Scientific Databases | 43 | Genomics/protein/drug databases and biomedical knowledge retrieval |
+| Scientific Databases | 44 | Genomics/protein/drug databases and biomedical knowledge retrieval |
 | Bioinformatics (gptomics) | 239 | Variant analysis, sequencing QC, DE, pathways, single-cell, and epigenomics |
 | Omics & Computational Biology | 59 | Single-cell/spatial, proteomics, cheminformatics, and protein design tools |
 | ClawBio Pipelines | 21 | Orchestration pipelines for scRNA, GWAS, ancestry, and structural workflows |
 | BioOS Extended Suite | 285 | Extended agent suite for oncology, immunology, clinical AI, and infrastructure |
 | Data Science & Tools | 93 | Statistics, visualization, automation, simulation, and scientific tooling |
-| **Total** | **869** | |
+| **Total** | **870** | |
 
 ---
 
@@ -493,6 +493,7 @@ Your agent should list the installed skills with their capabilities.
 | [cosmic-database](skills/cosmic-database/) | Access COSMIC cancer mutation database. Query somatic mutations, Cancer Gene Census, mutational signatures, gene fusions, for cancer research and precision oncology. Requires authentication. |
 | [ensembl-database](skills/ensembl-database/) | Query Ensembl genome database REST API for 250+ species. Gene lookups, sequence retrieval, variant analysis, comparative genomics, orthologs, VEP predictions, for genomic research. |
 | [gene-database](skills/gene-database/) | Query NCBI Gene via E-utilities/Datasets API. Search by symbol/ID, retrieve gene info (RefSeqs, GO, locations, phenotypes), batch lookups, for gene annotation and functional analysis. |
+| [genomic-intelligence](skills/genomic-intelligence/) | Predict regulatory features, gene structure, and expression directly from DNA sequence with Genomic Intelligence's hosted transformer DNA models (no local GPU). Six tasks over a REST API and a keyless MCP server: promoter regions, splice sites, enhancer activity, chromatin state, expression (log TPM), and de-novo gene annotation. |
 | [geo-database](skills/geo-database/) | Access NCBI GEO for gene expression/genomics data. Search/download microarray and RNA-seq datasets (GSE, GSM, GPL), retrieve SOFT/Matrix files, for transcriptomics and expression analysis. |
 | [ena-database](skills/ena-database/) | Access European Nucleotide Archive via API/FTP. Retrieve DNA/RNA sequences, raw reads (FASTQ), genome assemblies by accession, for genomics and bioinformatics pipelines. |
 | [gget](skills/gget/) | CLI/Python toolkit for rapid bioinformatics queries with access to 20+ databases: Ensembl, UniProt, AlphaFold, ARCHS4, Enrichr, OpenTargets, COSMIC, BLAST, and more. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -5,13 +5,13 @@
 [![GitHub Stars](https://img.shields.io/github/stars/FreedomIntelligence/OpenClaw-Medical-Skills?style=for-the-badge&logo=github&color=gold)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/stargazers)
 [![GitHub Forks](https://img.shields.io/github/forks/FreedomIntelligence/OpenClaw-Medical-Skills?style=for-the-badge&logo=github&color=blue)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/network/members)
 [![GitHub Issues](https://img.shields.io/github/issues/FreedomIntelligence/OpenClaw-Medical-Skills?style=for-the-badge&logo=github)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/issues)
-[![技能数量](https://img.shields.io/badge/技能数量-869-brightgreen?style=for-the-badge)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/tree/main/skills)
+[![技能数量](https://img.shields.io/badge/技能数量-870-brightgreen?style=for-the-badge)](https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills/tree/main/skills)
 [![License](https://img.shields.io/badge/License-MIT-purple?style=for-the-badge)](LICENSE)
 [![Platform](https://img.shields.io/badge/平台-OpenClaw%20%7C%20NanoClaw-orange?style=for-the-badge)](https://github.com/openclaw/openclaw)
 
 **最大的开源医疗 AI 技能库，专为 OpenClaw 框架设计。**
 
-*869 个精选技能 · 临床医学 · 基因组学 · 药物发现 · 生物信息学 · 医疗器械*
+*870 个精选技能 · 临床医学 · 基因组学 · 药物发现 · 生物信息学 · 医疗器械*
 
 [English](README.md) | [中文](#)
 
@@ -21,7 +21,7 @@
 
 ## 项目简介
 
-**OpenClaw Medical Skills** 是一个包含 **869 个 AI Agent 技能**的精选集合，覆盖生物医学与临床研究的完整领域。这些技能专为 [OpenClaw](https://github.com/openclaw/openclaw) / [NanoClaw](https://github.com/qwibitai/nanoclaw) —— 基于 Claude 的个人 AI 助手框架 —— 设计，能将通用 AI 智能体转变为强大的医学与科研研究伙伴。
+**OpenClaw Medical Skills** 是一个包含 **870 个 AI Agent 技能**的精选集合，覆盖生物医学与临床研究的完整领域。这些技能专为 [OpenClaw](https://github.com/openclaw/openclaw) / [NanoClaw](https://github.com/qwibitai/nanoclaw) —— 基于 Claude 的个人 AI 助手框架 —— 设计，能将通用 AI 智能体转变为强大的医学与科研研究伙伴。
 
 每个技能都是一个独立模块（`SKILL.md` 文件），它：
 - 为 Agent 注入专业领域知识与工作流
@@ -155,13 +155,13 @@ Agent 应当列出已安装的技能及其功能说明。
 |---|---|---|
 | 通用与核心 | 10 | 浏览器/搜索、文档处理与开发工作流工具 |
 | 医疗与临床 | 119 | 临床报告、决策支持、肿瘤学、影像与医疗 AI |
-| 科学数据库 | 43 | 基因组/蛋白/药物数据库与生物医学检索 |
+| 科学数据库 | 44 | 基因组/蛋白/药物数据库与生物医学检索 |
 | 生物信息学 (gptomics bio-* 套件) | 239 | 变异分析、测序质控、差异表达、通路与单细胞分析 |
 | 组学与计算生物学 | 59 | 单细胞/空间组学、蛋白质组、化学信息学与蛋白设计 |
 | ClawBio 管道 | 21 | 面向 scRNA、GWAS、祖先分析与结构生物学的编排流程 |
 | BioOS 扩展套件 | 285 | 覆盖肿瘤、免疫、临床 AI 与研究基础设施的扩展智能体 |
 | 数据科学与工具 | 93 | 统计、可视化、自动化、模拟与科研工具链 |
-| **总计** | **869** | |
+| **总计** | **870** | |
 
 ---
 
@@ -482,6 +482,7 @@ Agent 应当列出已安装的技能及其功能说明。
 | [cosmic-database](skills/cosmic-database/) | 访问 COSMIC 癌症突变数据库。查询体细胞突变、癌症基因普查、突变特征、基因融合，用于癌症研究和精准肿瘤学。需要认证。 |
 | [ensembl-database](skills/ensembl-database/) | 查询 Ensembl 基因组数据库 REST API（250+ 物种）。基因查询、序列检索、变异分析、比较基因组学、直系同源基因、VEP 预测。 |
 | [gene-database](skills/gene-database/) | 通过 E-utilities/Datasets API 查询 NCBI Gene。按符号/ID 检索，获取基因信息（RefSeq、GO、位置、表型），批量查询，用于基因注释。 |
+| [genomic-intelligence](skills/genomic-intelligence/) | 直接从 DNA 序列预测调控元件、基因结构与表达量，基于 Genomic Intelligence 托管的 Transformer DNA 模型（无需本地 GPU）。涵盖启动子、剪接位点、增强子活性、染色质状态、表达量（log TPM）与从头基因注释六项任务，提供 REST API 与免密钥 MCP 服务。 |
 | [geo-database](skills/geo-database/) | 访问 NCBI GEO 基因表达/基因组数据。搜索/下载微阵列和 RNA-seq 数据集（GSE、GSM、GPL），检索 SOFT/Matrix 文件，用于转录组分析。 |
 | [ena-database](skills/ena-database/) | 通过 API/FTP 访问欧洲核酸数据库。按登录号检索 DNA/RNA 序列、原始测序数据（FASTQ）、基因组组装，用于基因组学和生物信息学流程。 |
 | [gget](skills/gget/) | 快速生物信息查询的 CLI/Python 工具包，访问 20+ 数据库：Ensembl、UniProt、AlphaFold、ARCHS4、Enrichr、OpenTargets、COSMIC、BLAST 等。 |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -551,6 +551,7 @@
     "./skills/gene-panel-design-agent",
     "./skills/geniml",
     "./skills/genome-compare",
+    "./skills/genomic-intelligence",
     "./skills/geo-database",
     "./skills/geopandas",
     "./skills/gget",

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -94,7 +94,7 @@ in `references/tasks.md`.
 Two hard rules the model enforces:
 
 - **`expression` needs exactly 9,198 bp**, a window **centred on the TSS**
-  (2 × 4,599). Any other length is rejected. Use the acquisition helpers below to
+  (4,599 upstream + TSS + 4,598 downstream). Any other length is rejected. Use the acquisition helpers below to
   build it — do not truncate by hand.
 - **`expression` needs a `description`** — a cell-type / assay string (e.g.
   `"K562 cells"`), passed as `options.description`.
@@ -103,16 +103,18 @@ Two hard rules the model enforces:
 
 You rarely start from a raw 9,198 bp string. Acquire sequence first:
 
-- **From a gene symbol or region** → fetch reference sequence from Ensembl
-  (public, no key). MCP: `fetch_ensembl_sequence`, `fetch_region`,
-  `find_genes`. REST users can query Ensembl REST directly.
+- **From a gene symbol** → MCP `fetch_ensembl_sequence(gene=...)`; **from
+  coordinates** → `fetch_region(region=...)`. Both fetch public Ensembl reference
+  sequence (no key). REST users can query Ensembl REST directly. (`find_genes` is
+  the annotation task, not an acquisition tool.)
 - **For `expression`** → use the TSS-centred fetch so the window is exactly
   9,198 bp. MCP: `fetch_gene_for_expression` (handles the centring). Do not
   build the window by hand.
-- **From a local FASTA** → MCP `load_local_fasta` / `store_inline_sequence`, or
-  read the file yourself for REST.
-- **A demo sequence** → MCP `load_demo_sequence` returns a ready handle (great
-  for a keyless smoke test).
+- **From a local FASTA** → MCP `store_inline_sequence`, or read the file yourself
+  for REST. (`load_local_fasta` exists only in local deployments, not on the
+  hosted server.)
+- **A demo sequence** → MCP `load_demo_sequence(name=...)` returns a ready handle
+  (great for a keyless smoke test); `name` is required.
 
 See `references/sequence-acquisition.md` for the exact Ensembl calls and the
 expression-window math.
@@ -174,9 +176,10 @@ On an MCP host, acquire a handle, then predict against it — sequences stay out
 the context:
 
 ```
-# 1. Acquire a sequence handle (any of these return a sequence_ref):
-load_demo_sequence()                      # keyless smoke test
-fetch_ensembl_sequence(region="TP53")     # gene or region -> handle
+# 1. Acquire a sequence handle (each returns a sequence_ref):
+load_demo_sequence(name="promoter_tp53")  # keyless smoke test; `name` is REQUIRED
+fetch_ensembl_sequence(gene="TP53")       # gene symbol or Ensembl ID -> handle
+fetch_region(region="chr11:5,225,000-5,235,000")   # coordinates -> handle
 fetch_gene_for_expression(gene="HBB")     # TSS-centred 9,198 bp handle for expression
 
 # 2. Predict against the handle:
@@ -184,7 +187,11 @@ predict_promoter(sequence_ref=<ref>)
 predict_expression(sequence_ref=<ref>, description="K562 cells")
 predict_splice(sequence_ref=<ref>)        # + predict_enhancer / predict_chromatin
 
-# 3. Annotation is async: submit, then poll get_job(job_id) until terminal.
+# 3. Annotation on MCP is `find_genes` (there is no predict_annotation).
+#    It takes a handle, not a region, and runs async internally:
+find_genes(sequence_ref=<ref>)            # wait=True (default) returns the result
+find_genes(sequence_ref=<ref>, wait=False)  # -> job_id; poll get_job(job_id)
+
 # Discover models with list_models(task); reference context lives in the
 # gi://models, gi://docs/tasks, and gi://account MCP resources.
 ```
@@ -194,8 +201,10 @@ predict_splice(sequence_ref=<ref>)        # + predict_enhancer / predict_chromat
 To answer "what genes are in this region and how are they expressed?", use the
 composite:
 
-- **MCP:** `find_genes_and_predict_expression(region=..., description=...)` —
-  finds genes in the region and returns an expression prediction for each.
+- **MCP:** `find_genes_and_predict_expression(sequence_ref=..., description=...)`
+  — takes a **handle, not a region** (acquire one with `fetch_region` first);
+  `description` is required. Finds genes in the sequence and returns an
+  expression prediction for each.
 - **REST:** call gene discovery, then loop `expression` per gene (build each
   TSS-centred 9,198 bp window via the acquisition helpers).
 
@@ -207,6 +216,7 @@ composite:
 | 401 | Missing/invalid key (REST) | Set `GI_API_KEY`; or use the keyless MCP demo |
 | 413 | Sequence too long | Stay within the task's length bound (≤500,000 bp) |
 | 429 | Rate / concurrency cap | Back off and retry; ask GI to raise your tier |
+| 422 | Validation failed (`validation_failed`) | The most common failure: expression not exactly 9,198 bp, or a sequence below the model's minimum length |
 | 5xx | Server error | Retry; if persistent, contact support |
 
 ## Reference files

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -79,13 +79,13 @@ same strings clients already POST to, so no URL construction changes; the shared
 `PredictRequest` schema is gone. Body is `{sequence, sequence_name?, model?,
 options?}`, returning a `{data, meta}` envelope. What differs per task:
 
-| Task | Mode | Accepted length | Model context window | Notes |
+| Task | Mode | Accepted length | `context_window_bp` | Notes |
 |---|---|---|---|---|
 | `promoter` | sync | 300–500,000 bp | 2,000 bp | sliding-window promoter regions |
 | `splice` | sync | 100–500,000 bp | 15,000 bp | donor/acceptor sites (long-context BigBird); strand-specific — feed transcript orientation |
 | `enhancer` | sync | 50–500,000 bp | 249 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 200–500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **9,198–500,000 bp** | 9,198 bp (fixed) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
+| `expression` | sync | **9,198–500,000 bp** | n/a (`trained_window_bp` 9,198) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
 | `annotation` | **async** | 1,000–500,000 bp | n/a | de-novo transcripts; submit + poll |
 
 **The minimum is admission control, not regime.** A request above the floor but

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: genomic-intelligence
+description: "Predict regulatory features, gene structure, and expression directly from DNA sequence with Genomic Intelligence's hosted transformer DNA language models (no local GPU or weights). Six tasks over a REST API and a keyless hosted MCP server: promoter regions, splice donor/acceptor sites, enhancer activity, chromatin state, sequence-to-expression (log TPM), and de-novo gene annotation, plus a find-genes-then-predict-expression composite. Use when the user has a gene symbol, a genomic region, or a DNA/FASTA sequence and wants any of these predictions, or mentions Genomic Intelligence, genomicintelligence.ai, or mcp.genomicintelligence.ai."
+---
+
+# Genomic Intelligence — DNA Sequence Models
+
+Genomic Intelligence (GI) serves transformer DNA language models over six
+sequence-analysis tasks on managed GPUs. Give it a **gene symbol**, a **genomic
+region**, or a **DNA/FASTA sequence**; it returns structured predictions —
+promoter regions, splice sites, enhancer activity, chromatin state, expression
+(log TPM), and de-novo gene annotation. Nothing runs locally: no model weights,
+no GPU, no heavy Python stack. It is a thin client over a hosted, versioned
+inference API.
+
+**Official docs:** [docs.genomicintelligence.ai](https://docs.genomicintelligence.ai) ·
+REST contract at [api.genomicintelligence.ai/v1/openapi.json](https://api.genomicintelligence.ai/v1/openapi.json) ·
+hosted MCP server at `https://mcp.genomicintelligence.ai/mcp`
+
+## When to use this skill
+
+Use GI when the user has DNA and wants a model prediction:
+
+- **Find promoters** in a genomic region (`promoter`)
+- **Predict splice** donor/acceptor sites (`splice`)
+- **Score enhancer activity** — developmental & housekeeping (`enhancer`)
+- **Annotate chromatin state** across hundreds of tracks (`chromatin`)
+- **Predict expression** as log(TPM+1) from a sequence + cell-type context (`expression`)
+- **Annotate genes/transcripts** de novo, no reference needed (`annotation`)
+- **Find the genes in a region and predict each one's expression** (composite)
+
+Not for local alignment, variant calling, or file I/O — use a local tool
+(BioPython, bcftools) for those. GI is for **model inference from sequence**.
+
+> For research and development use, **not clinical or diagnostic decisions**.
+
+## Two ways to call GI
+
+### Hosted MCP server (best for AI agents — keyless)
+
+GI hosts an MCP server at `https://mcp.genomicintelligence.ai/mcp` (Streamable
+HTTP). When your agent host supports MCP, prefer it: it works **keyless** against
+a capped public demo quota (zero setup), and an optional `gi_` bearer key raises
+the quota. It exposes acquisition tools that return a **sequence handle**
+(`sequence_ref`) and `predict_*` tools that take that handle — so large sequences
+never bloat the context. See [MCP workflow](#mcp-workflow-handle-based) and
+`references/mcp.md`.
+
+### REST API (universal)
+
+Plain HTTP with `requests` against `https://api.genomicintelligence.ai/v1`. The
+REST path **requires** a `GI_API_KEY` (a `gi_` bearer). Use it on any host, in
+scripts, or when you need the raw envelope. See [Core REST workflow](#core-rest-workflow).
+
+## Access and authentication
+
+1. The **hosted MCP demo is keyless** — try it with nothing set.
+2. The **REST `/v1` API needs a key**, sent as `Authorization: Bearer <key>`.
+   Request one at [contact@genomicintelligence.ai](mailto:contact@genomicintelligence.ai).
+3. **Never hardcode the key.** Read it from the `GI_API_KEY` environment variable
+   (or a `.env` via `python-dotenv`). Never commit keys.
+
+```bash
+export GI_API_KEY="gi_yourkeyhere"     # optional for MCP; required for REST
+export GI_BASE_URL="https://api.genomicintelligence.ai"   # override for staging
+```
+
+Keys are scoped to a partner tier with concurrency and per-minute caps. A `429`
+means you hit a cap — back off and retry, or ask GI to raise your tier.
+
+## The six tasks
+
+All REST tasks share one shape: `POST /v1/tasks/{task}/predict` with body
+`{sequence, sequence_name, model?, options?}`, returning a `{data, meta}`
+envelope. What differs per task:
+
+| Task | Mode | Length bound | Notes |
+|---|---|---|---|
+| `promoter` | sync | 1–500,000 bp | sliding-window promoter regions |
+| `splice` | sync | 1–500,000 bp | donor/acceptor sites (long-context BigBird) |
+| `enhancer` | sync | 1–500,000 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
+| `chromatin` | sync | 1–500,000 bp | hundreds of tracks (DeepSEA) |
+| `expression` | sync | **exactly 9,198 bp** | log(TPM+1); needs a cell-type `description` |
+| `annotation` | **async** | 1–500,000 bp | de-novo transcripts; submit + poll |
+
+**Omit `model` and the API uses the task's default** — that is the recommended
+call. Default model IDs are intentionally **not** documented here: defaults
+change and retired IDs fail hard, so never hardcode one. To pin a model, or to
+pick a non-human one (Drosophila, yeast, and Arabidopsis models exist for several
+tasks), discover IDs at call time with `GET /v1/tasks/{task}/models` (REST) or
+`list_models` (MCP) — and **never invent one**. Full per-task output shapes are
+in `references/tasks.md`.
+
+Two hard rules the model enforces:
+
+- **`expression` needs exactly 9,198 bp**, a window **centred on the TSS**
+  (2 × 4,599). Any other length is rejected. Use the acquisition helpers below to
+  build it — do not truncate by hand.
+- **`expression` needs a `description`** — a cell-type / assay string (e.g.
+  `"K562 cells"`), passed as `options.description`.
+
+## Sequence acquisition
+
+You rarely start from a raw 9,198 bp string. Acquire sequence first:
+
+- **From a gene symbol or region** → fetch reference sequence from Ensembl
+  (public, no key). MCP: `fetch_ensembl_sequence`, `fetch_region`,
+  `find_genes`. REST users can query Ensembl REST directly.
+- **For `expression`** → use the TSS-centred fetch so the window is exactly
+  9,198 bp. MCP: `fetch_gene_for_expression` (handles the centring). Do not
+  build the window by hand.
+- **From a local FASTA** → MCP `load_local_fasta` / `store_inline_sequence`, or
+  read the file yourself for REST.
+- **A demo sequence** → MCP `load_demo_sequence` returns a ready handle (great
+  for a keyless smoke test).
+
+See `references/sequence-acquisition.md` for the exact Ensembl calls and the
+expression-window math.
+
+## Core REST workflow
+
+Sync tasks (promoter, splice, enhancer, chromatin, expression) are one call:
+
+```python
+import os, requests
+
+BASE = os.environ.get("GI_BASE_URL", "https://api.genomicintelligence.ai")
+HEADERS = {"Authorization": f"Bearer {os.environ['GI_API_KEY']}"}
+
+def predict(task, sequence, sequence_name, model=None, options=None):
+    body = {"sequence": sequence, "sequence_name": sequence_name}
+    if model:   body["model"] = model
+    if options: body["options"] = options
+    r = requests.post(f"{BASE}/v1/tasks/{task}/predict", headers=HEADERS, json=body)
+    r.raise_for_status()          # 400 invalid; 401 no/bad key; 413 too long; 429 rate limit
+    return r.json()               # {"data": {...}, "meta": {...}}
+
+# Promoter:
+out = predict("promoter", seq, "TP53_region")
+print(out["data"]["summary"])
+
+# Expression — exactly 9,198 bp + a cell-type description:
+out = predict("expression", tss_window_9198bp, "HBB",
+              options={"description": "K562 cells"})
+print(out["data"]["prediction"]["expression_log_tpm"])
+```
+
+### Async: annotation
+
+`annotation` is submit-then-poll. Send `Prefer: respond-async`, get a `job_id`,
+poll until terminal:
+
+```python
+import time
+
+r = requests.post(f"{BASE}/v1/tasks/annotation/predict",
+                  headers={**HEADERS, "Prefer": "respond-async"},
+                  json={"sequence": seq, "sequence_name": "TP53"})
+r.raise_for_status()              # 202 Accepted
+job_id = r.json()["data"]["job_id"]
+
+while True:
+    j = requests.get(f"{BASE}/v1/tasks/jobs/{job_id}", headers=HEADERS)
+    if j.status_code == 200:      # terminal: body is the final {data, meta}
+        break
+    j.raise_for_status()          # 202 = still running (2xx, won't raise)
+    time.sleep(5)                 # ~20 s typical for ~20 kb
+transcripts = j.json()["data"]["transcripts"]
+```
+
+## MCP workflow (handle-based)
+
+On an MCP host, acquire a handle, then predict against it — sequences stay out of
+the context:
+
+```
+# 1. Acquire a sequence handle (any of these return a sequence_ref):
+load_demo_sequence()                      # keyless smoke test
+fetch_ensembl_sequence(region="TP53")     # gene or region -> handle
+fetch_gene_for_expression(gene="HBB")     # TSS-centred 9,198 bp handle for expression
+
+# 2. Predict against the handle:
+predict_promoter(sequence_ref=<ref>)
+predict_expression(sequence_ref=<ref>, description="K562 cells")
+predict_splice(sequence_ref=<ref>)        # + predict_enhancer / predict_chromatin
+
+# 3. Annotation is async: submit, then poll get_job(job_id) until terminal.
+# Discover models with list_models(task); reference context lives in the
+# gi://models, gi://docs/tasks, and gi://account MCP resources.
+```
+
+## Composite: find genes, then predict expression
+
+To answer "what genes are in this region and how are they expressed?", use the
+composite:
+
+- **MCP:** `find_genes_and_predict_expression(region=..., description=...)` —
+  finds genes in the region and returns an expression prediction for each.
+- **REST:** call gene discovery, then loop `expression` per gene (build each
+  TSS-centred 9,198 bp window via the acquisition helpers).
+
+## Errors
+
+| Code | Meaning | Action |
+|---|---|---|
+| 400 | Invalid request / bad sequence | Check the body; expression must be exactly 9,198 bp and carry `description` |
+| 401 | Missing/invalid key (REST) | Set `GI_API_KEY`; or use the keyless MCP demo |
+| 413 | Sequence too long | Stay within the task's length bound (≤500,000 bp) |
+| 429 | Rate / concurrency cap | Back off and retry; ask GI to raise your tier |
+| 5xx | Server error | Retry; if persistent, contact support |
+
+## Reference files
+
+- `references/tasks.md` — per-task output shapes, model registries, the async
+  annotation contract.
+- `references/api-and-auth.md` — REST endpoints, the `{data, meta}` envelope,
+  auth, base-URL override, tiers.
+- `references/mcp.md` — the hosted MCP tool list, the handle-based flow, and the
+  `gi://` resources.
+- `references/sequence-acquisition.md` — Ensembl fetch calls and the
+  expression-window (9,198 bp, TSS-centred) math.

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -70,18 +70,53 @@ means you hit a cap — back off and retry, or ask GI to raise your tier.
 
 ## The six tasks
 
-All REST tasks share one shape: `POST /v1/tasks/{task}/predict` with body
-`{sequence, sequence_name, model?, options?}`, returning a `{data, meta}`
-envelope. What differs per task:
+Each task is **its own published operation** with its own request schema, its own
+minimum length, and its own closed `options` object — `POST
+/v1/tasks/promoter/predict`, `/v1/tasks/splice/predict`,
+`/v1/tasks/enhancer/predict`, `/v1/tasks/chromatin/predict`,
+`/v1/tasks/annotation/predict`, `/v1/tasks/expression/predict`. The URLs are the
+same strings clients already POST to, so no URL construction changes; the shared
+`PredictRequest` schema is gone. Body is `{sequence, sequence_name?, model?,
+options?}`, returning a `{data, meta}` envelope. What differs per task:
 
-| Task | Mode | Length bound | Notes |
-|---|---|---|---|
-| `promoter` | sync | 1–500,000 bp | sliding-window promoter regions |
-| `splice` | sync | 1–500,000 bp | donor/acceptor sites (long-context BigBird) |
-| `enhancer` | sync | 1–500,000 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
-| `chromatin` | sync | 1–500,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **9,198–500,000 bp** | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
-| `annotation` | **async** | 1–500,000 bp | de-novo transcripts; submit + poll |
+| Task | Mode | Accepted length | Model context window | Notes |
+|---|---|---|---|---|
+| `promoter` | sync | 300–500,000 bp | 2,000 bp | sliding-window promoter regions |
+| `splice` | sync | 100–500,000 bp | 15,000 bp | donor/acceptor sites (long-context BigBird); strand-specific — feed transcript orientation |
+| `enhancer` | sync | 50–500,000 bp | 249 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
+| `chromatin` | sync | 200–500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
+| `expression` | sync | **9,198–500,000 bp** | 9,198 bp (fixed) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
+| `annotation` | **async** | 1,000–500,000 bp | n/a | de-novo transcripts; submit + poll |
+
+**The minimum is admission control, not regime.** A request above the floor but
+shorter than the selected model's `bio_spec.context_window_bp` is *accepted and
+scored* — against a window padded out to the context window. Enhancer is the
+sharp case: the bound is 50 bp (DeepSTARR's gate) but the context window is
+249 bp, so 50–248 bp is scored mostly on padding. Compare your length against
+`context_window_bp` from `GET /v1/tasks/{task}/models` to know whether the model
+saw real sequence. Longer-than-context input is fine — the scanner steps a
+prediction window at a time and pads only the final partial window.
+
+Under the floor and over the 500,000 bp cap are **both `422 validation_failed`**
+at `loc ["body","sequence"]`; over-length is *not* a `413`. All lengths are
+measured after whitespace is stripped, so a line-wrapped FASTA body can be pasted
+verbatim (a `>` header line still fails the alphabet check).
+
+`options` is typed and **closed** (`additionalProperties: false`) per task — an
+unknown key is a hard `422 validation_failed` with `type: "extra_forbidden"`,
+never ignored:
+
+| Task | `options` keys |
+|---|---|
+| promoter | `threshold` (0–1, default 0.5) |
+| splice | `threshold` (0–1, default 0.5), `site_types` (subset of `["donor","acceptor"]`, default both) |
+| enhancer | *(none)* |
+| chromatin | `threshold` (0–1, default 0.5) |
+| annotation | `batch_size` (1–128, default 8), `shift_coordinates`, `reverse_complement` (default true) |
+| expression | `description` — **required**, and the only key |
+
+`Prefer: respond-async` is a declared header on **all six** predict operations
+and on the composite, not just `annotation` — see [Async](#async-any-task-annotation-always).
 
 **Omit `model` and the API uses the task's default** — that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults
@@ -91,10 +126,10 @@ tasks), discover IDs at call time with `GET /v1/tasks/{task}/models` (REST) or
 `list_models` (MCP) — and **never invent one**. Full per-task output shapes are
 in `references/tasks.md`.
 
-`expression` is the one task with its own published operation (same URL,
-`POST /v1/tasks/expression/predict`, its own request schema). Three hard rules
-it enforces — every violation is a `422`, nothing is padded or clamped, and
-there is no opt-out flag, header, or query parameter:
+`expression` is the strictest of the six: alone among them its schema requires
+`options` as well as `sequence`. Three hard rules it enforces — every violation
+is a `422`, nothing is padded or clamped, and there is no opt-out flag, header,
+or query parameter:
 
 - **It always scores exactly one 9,198 bp TSS-centred window** —
   `sequence[tss_index-4599 : tss_index+4599]`. The endpoint itself accepts
@@ -118,6 +153,11 @@ there is no opt-out flag, header, or query parameter:
 > Also note `data.input.sequence_length` is the **scored** length (always
 > 9,198); the length you submitted is `data.input.submitted_sequence_length`
 > (and `meta.sequence_length`).
+>
+> Both `tss_index` violations — "required unless exactly 9,198 bp" and the range
+> check — come from a whole-model validator, so they report at `loc: ["body"]`,
+> **never** `body.tss_index`. Match on `error.code == "validation_failed"`; use
+> the message for display only, and never branch on `loc`.
 
 ## Sequence acquisition
 
@@ -156,8 +196,13 @@ def predict(task, sequence, sequence_name, model=None, options=None, tss_index=N
     if model:   body["model"] = model
     if options: body["options"] = options
     if tss_index is not None: body["tss_index"] = tss_index   # expression only
+    # Each task is its own published operation, but the URL string is unchanged.
     r = requests.post(f"{BASE}/v1/tasks/{task}/predict", headers=HEADERS, json=body)
-    r.raise_for_status()          # 422 validation; 401 no/bad key; 413 too long; 429 rate limit
+    # 422 validation_failed  — sequence under the task floor OR over 500,000 bp,
+    #                          bad tss_index, missing options.description,
+    #                          or ANY unknown body/options key (options is closed)
+    # 401 no/bad key · 404 unknown task · 413 body over 16 MiB · 429 rate limit
+    r.raise_for_status()
     return r.json()               # {"data": {...}, "meta": {...}}
 
 # Promoter:
@@ -176,10 +221,14 @@ out = predict("expression", locus_seq, "HBB",
 print(out["meta"]["task_specific_counts"]["scored_window"])   # confirm the window scored
 ```
 
-### Async: annotation
+### Async (any task; annotation always)
 
-`annotation` is submit-then-poll. Send `Prefer: respond-async`, get a `job_id`,
-poll until terminal:
+`Prefer: respond-async` is a declared header parameter on all six predict
+operations and on the composite. A `202` carries the same `{data, meta}` envelope
+as a sync `200`, with `data = {job_id, status: "accepted", links}`; the job id is
+also in the `Content-Location` and `X-Job-Id` response headers. Async is
+JSON-only — combining it with a text `format` is rejected. `annotation` is the
+task that needs it:
 
 ```python
 import time
@@ -234,19 +283,56 @@ composite:
   — takes a **handle, not a region** (acquire one with `fetch_region` first);
   `description` is required. Finds genes in the sequence and returns an
   expression prediction for each.
-- **REST:** call gene discovery, then loop `expression` per gene (build each
-  TSS-centred 9,198 bp window via the acquisition helpers).
+- **REST:** one call — `POST /v1/workflows/find-genes-and-predict-expression`,
+  body `{sequence, options}` with `sequence` 1,000–500,000 bp and
+  `options.description` (cell type / assay) required; a missing or empty
+  description is a `422 validation_failed`. It annotates, centres a 9,198 bp
+  window on each discovered gene's TSS (padding with `N` up to half the window
+  rather than dropping an edge gene), and returns a prediction per gene.
+  `meta.task_specific_counts` = `{genes_found, genes_predicted, genes_skipped}`
+  with `genes_predicted + genes_skipped == genes_found`; per-gene causes in
+  `data.expression_predictions[].skip_reason`. Above **50,000 bp** it forces
+  async: a synchronous request over that size is `413 sync_too_large` with
+  `error.details = {sequence_length, threshold}` — retry the same body with
+  `Prefer: respond-async`.
 
 ## Errors
 
-| Code | Meaning | Action |
-|---|---|---|
-| 400 | Invalid request / bad sequence | Check the body shape |
-| 401 | Missing/invalid key (REST) | Set `GI_API_KEY`; or use the keyless MCP demo |
-| 413 | Sequence too long | Stay within the task's length bound (≤500,000 bp) |
-| 429 | Rate / concurrency cap | Back off and retry; ask GI to raise your tier |
-| 422 | Validation failed (`validation_failed`) | The most common failure: expression below 9,198 bp, a missing or out-of-range `tss_index`, or a missing `options.description` |
-| 5xx | Server error | Retry; if persistent, contact support |
+| Code | `error.code` | Meaning | Action |
+|---|---|---|---|
+| 400 | `bad_request` | Malformed request | Check the body shape |
+| 401 / 403 | `unauthorized` / `forbidden` | Missing/invalid key (REST) | Set `GI_API_KEY`; or use the keyless MCP demo |
+| 404 | `not_found` | **Unknown task** (`/v1/tasks/bogus/predict`) or unknown job | Check the task name — an unrecognised task is a 404, not a 422 |
+| 413 | `payload_too_large` | Raw request body over **16 MiB** | Split the input — this is the body cap, not the sequence cap |
+| 413 | `sync_too_large` | Composite called synchronously above 50,000 bp | Retry with `Prefer: respond-async` |
+| 415 | `unsupported_format` | Unsupported `format` query value | Use a format the task supports; there is no silent fallback to JSON |
+| 422 | `validation_failed` | The most common failure: sequence **under the task floor or over 500,000 bp**, expression below 9,198 bp, a missing/out-of-range `tss_index`, a missing `options.description`, or **any unknown body or `options` key** | Read the message; fix the body |
+| 429 | `rate_limited` / `too_many_requests` | Rate / concurrency cap | Back off (honour `Retry-After`); ask GI to raise your tier |
+| 5xx | `internal_error` / `service_unavailable` / `model_loading` / `timeout` | Server error | Retry; if persistent, contact support |
+
+`error.code` is a closed 21-value enum (`bad_request`, `unauthorized`,
+`forbidden`, `not_found`, `conflict`, `job_expired`, `payload_too_large`,
+`sync_too_large`, `unsupported_format`, `validation_failed`,
+`too_many_requests`, `rate_limited`, `internal_error`, `timeout`,
+`insufficient_memory`, `model_not_found`, `task_not_supported_by_model`,
+`model_loading`, `service_unavailable`, `http_error`, `unknown`); treat an
+unlisted value as a generic failure, not a parse error.
+
+**Branch on `code`, never on `details` or `loc`.** `details` is documented as
+keyed on the sibling `code`, but a validation failure currently arrives as a bare
+FastAPI error *array* (`[{loc, msg, type}, …]`) rather than the `{errors: […]}`
+object the schema declares — read it defensively and keep control flow off it.
+
+`error.request_id` is always populated and mirrors the `X-Request-Id` header.
+Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
+`RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
+
+> Schema-version note: this describes the contract served from `2026.08.19.4`.
+> `api.genomicintelligence.ai` may still be on `2026.08.18.1` until that build is
+> promoted, where the six literal operations, the typed `options`, the per-task
+> floors, the published composite, the `Prefer` parameter, the `code` enum and the
+> new `bio_spec` fields are not yet present. URLs and envelopes are the same
+> either way — check `info.version` in `/v1/openapi.json`.
 
 ## Reference files
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -79,14 +79,16 @@ same strings clients already POST to, so no URL construction changes; the shared
 `PredictRequest` schema is gone. Body is `{sequence, sequence_name?, model?,
 options?}`, returning a `{data, meta}` envelope. What differs per task:
 
-| Task | Mode | Accepted length | `context_window_bp` | Notes |
+| Task | Recommended mode | Accepted length | `context_window_bp` | Notes |
 |---|---|---|---|---|
 | `promoter` | sync | 300–500,000 bp | 2,000 bp | sliding-window promoter regions |
 | `splice` | sync | 100–500,000 bp | 15,000 bp | donor/acceptor sites (long-context BigBird); strand-specific — feed transcript orientation |
 | `enhancer` | sync | 50–500,000 bp | 249 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 200–500,000 bp | 1,000 bp | hundreds of tracks (DeepSEA) |
 | `expression` | sync | **9,198–500,000 bp** | n/a (`trained_window_bp` 9,198) | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
-| `annotation` | **async** | 1,000–500,000 bp | n/a | de-novo transcripts; submit + poll |
+| `annotation` | async | 1,000–500,000 bp | n/a | de-novo transcripts; submit + poll |
+
+`Recommended mode` is guidance, not a constraint — every task accepts both. Omit `Prefer` for a synchronous `200`; send `Prefer: respond-async` for a `202` plus `GET /v1/tasks/jobs/{job_id}`. Only the composite workflow enforces a mode, rejecting sync above 50,000 bp with `413 sync_too_large`.
 
 **The minimum is admission control, not regime.** A request above the floor but
 shorter than the selected model's `bio_spec.context_window_bp` is *accepted and

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -320,23 +320,20 @@ composite:
 `model_loading`, `service_unavailable`, `http_error`, `unknown`); treat an
 unlisted value as a generic failure, not a parse error.
 
-**Branch on `code`, never on `details` or `loc`.** `details` is documented as
-keyed on the sibling `code`, but a validation failure currently arrives as a bare
-FastAPI error *array* (`[{loc, msg, type}, …]`) rather than the `{errors: […]}`
-object the schema declares — read it defensively and keep control flow off it.
+**Branch on `code`, never on `details` or `loc`.** `details` is keyed on the
+sibling `code`; a validation failure carries the declared `{errors: [{loc, msg,
+type}, …]}` object — read it defensively and keep control flow off it.
 
-`error.request_id` mirrors the `X-Request-Id` header. The header is set on every
-response; the body field is not — `413 sync_too_large` omits it — so fall back to
-the header.
+`error.request_id` mirrors the `X-Request-Id` header, and both are set on every
+response; success envelopes carry `meta.request_id`.
 Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
 `RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
 
-> Schema-version note: this describes the contract served from `2026.08.19.4`.
-> `api.genomicintelligence.ai` may still be on `2026.08.18.1` until that build is
-> promoted, where the six literal operations, the typed `options`, the per-task
-> floors, the published composite, the `Prefer` parameter, the `code` enum and the
-> new `bio_spec` fields are not yet present. URLs and envelopes are the same
-> either way — check `info.version` in `/v1/openapi.json`.
+> Schema-version note: this describes gpu_service `2026.08.19.5`, live on
+> `api.genomicintelligence.ai` — the six literal operations, the typed `options`,
+> the per-task floors, the published composite, the `Prefer` parameter, the `code`
+> enum and the `bio_spec` fields are all present. Check `info.version` in
+> `/v1/openapi.json` if a detail here does not match.
 
 ## Reference files
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -80,7 +80,7 @@ envelope. What differs per task:
 | `splice` | sync | 1–500,000 bp | donor/acceptor sites (long-context BigBird) |
 | `enhancer` | sync | 1–500,000 bp | dev + housekeeping scores (DeepSTARR, *Drosophila*) |
 | `chromatin` | sync | 1–500,000 bp | hundreds of tracks (DeepSEA) |
-| `expression` | sync | **exactly 9,198 bp** | log(TPM+1); needs a cell-type `description` |
+| `expression` | sync | **9,198–500,000 bp** | log(TPM+1); needs `tss_index` unless exactly 9,198 bp, plus a cell-type `description` |
 | `annotation` | **async** | 1–500,000 bp | de-novo transcripts; submit + poll |
 
 **Omit `model` and the API uses the task's default** — that is the recommended
@@ -91,13 +91,33 @@ tasks), discover IDs at call time with `GET /v1/tasks/{task}/models` (REST) or
 `list_models` (MCP) — and **never invent one**. Full per-task output shapes are
 in `references/tasks.md`.
 
-Two hard rules the model enforces:
+`expression` is the one task with its own published operation (same URL,
+`POST /v1/tasks/expression/predict`, its own request schema). Three hard rules
+it enforces — every violation is a `422`, nothing is padded or clamped, and
+there is no opt-out flag, header, or query parameter:
 
-- **`expression` needs exactly 9,198 bp**, a window **centred on the TSS**
-  (4,599 upstream + TSS + 4,598 downstream). Any other length is rejected. Use the acquisition helpers below to
-  build it — do not truncate by hand.
-- **`expression` needs a `description`** — a cell-type / assay string (e.g.
-  `"K562 cells"`), passed as `options.description`.
+- **It always scores exactly one 9,198 bp TSS-centred window** —
+  `sequence[tss_index-4599 : tss_index+4599]`. The endpoint itself accepts
+  **9,198–500,000 bp**; anything below 9,198 bp is rejected outright.
+- **`tss_index` is required unless the sequence is exactly 9,198 bp.** It is the
+  0-based TSS offset into the **whitespace-stripped** sequence, bounded by
+  `4599 ≤ tss_index ≤ len(sequence) − 4599`. At exactly 9,198 bp it defaults to
+  4,599, the only legal value there. So you may submit a whole locus (up to
+  500 kb) and let the server cut the window — but the server does **not**
+  discover the TSS for you (that is the composite workflow's job), and does
+  **not** reverse-complement: submit gene-sense sequence.
+- **`options.description`** — a cell-type / assay string (e.g. `"K562 cells"`) —
+  is required, and is the **only** key `expression` accepts inside `options`.
+  Unknown top-level body fields are rejected too.
+
+> Gotcha: the legal `tss_index` range is wide, so an offset that is merely
+> *wrong* (counted over raw FASTA characters including newlines, or relative to
+> a locus start rather than the submitted slice) does not error — it returns a
+> confident `200` for the wrong window. Assert on
+> `meta.task_specific_counts.scored_window` / `.tss_index` in the response.
+> Also note `data.input.sequence_length` is the **scored** length (always
+> 9,198); the length you submitted is `data.input.submitted_sequence_length`
+> (and `meta.sequence_length`).
 
 ## Sequence acquisition
 
@@ -108,8 +128,10 @@ You rarely start from a raw 9,198 bp string. Acquire sequence first:
   sequence (no key). REST users can query Ensembl REST directly. (`find_genes` is
   the annotation task, not an acquisition tool.)
 - **For `expression`** → use the TSS-centred fetch so the window is exactly
-  9,198 bp. MCP: `fetch_gene_for_expression` (handles the centring). Do not
-  build the window by hand.
+  9,198 bp. MCP: `fetch_gene_for_expression` (handles the centring). Otherwise
+  fetch a wider locus and pass the TSS as `tss_index` so the server cuts the
+  window — but compute that offset on the stripped nucleotide string, not on
+  file characters.
 - **From a local FASTA** → MCP `store_inline_sequence`, or read the file yourself
   for REST. (`load_local_fasta` exists only in local deployments, not on the
   hosted server.)
@@ -129,22 +151,29 @@ import os, requests
 BASE = os.environ.get("GI_BASE_URL", "https://api.genomicintelligence.ai")
 HEADERS = {"Authorization": f"Bearer {os.environ['GI_API_KEY']}"}
 
-def predict(task, sequence, sequence_name, model=None, options=None):
+def predict(task, sequence, sequence_name, model=None, options=None, tss_index=None):
     body = {"sequence": sequence, "sequence_name": sequence_name}
     if model:   body["model"] = model
     if options: body["options"] = options
+    if tss_index is not None: body["tss_index"] = tss_index   # expression only
     r = requests.post(f"{BASE}/v1/tasks/{task}/predict", headers=HEADERS, json=body)
-    r.raise_for_status()          # 400 invalid; 401 no/bad key; 413 too long; 429 rate limit
+    r.raise_for_status()          # 422 validation; 401 no/bad key; 413 too long; 429 rate limit
     return r.json()               # {"data": {...}, "meta": {...}}
 
 # Promoter:
 out = predict("promoter", seq, "TP53_region")
 print(out["data"]["summary"])
 
-# Expression — exactly 9,198 bp + a cell-type description:
+# Expression — a pre-cut 9,198 bp TSS-centred window (tss_index defaults to 4,599):
 out = predict("expression", tss_window_9198bp, "HBB",
               options={"description": "K562 cells"})
 print(out["data"]["prediction"]["expression_log_tpm"])
+
+# Expression — a whole locus; the server slices ±4,599 bp around the TSS you name.
+# tss_index is 0-based into the whitespace-stripped sequence.
+out = predict("expression", locus_seq, "HBB",
+              options={"description": "K562 cells"}, tss_index=tss_offset_in_locus)
+print(out["meta"]["task_specific_counts"]["scored_window"])   # confirm the window scored
 ```
 
 ### Async: annotation
@@ -212,11 +241,11 @@ composite:
 
 | Code | Meaning | Action |
 |---|---|---|
-| 400 | Invalid request / bad sequence | Check the body; expression must be exactly 9,198 bp and carry `description` |
+| 400 | Invalid request / bad sequence | Check the body shape |
 | 401 | Missing/invalid key (REST) | Set `GI_API_KEY`; or use the keyless MCP demo |
 | 413 | Sequence too long | Stay within the task's length bound (≤500,000 bp) |
 | 429 | Rate / concurrency cap | Back off and retry; ask GI to raise your tier |
-| 422 | Validation failed (`validation_failed`) | The most common failure: expression not exactly 9,198 bp, or a sequence below the model's minimum length |
+| 422 | Validation failed (`validation_failed`) | The most common failure: expression below 9,198 bp, a missing or out-of-range `tss_index`, or a missing `options.description` |
 | 5xx | Server error | Retry; if persistent, contact support |
 
 ## Reference files
@@ -228,4 +257,4 @@ composite:
 - `references/mcp.md` — the hosted MCP tool list, the handle-based flow, and the
   `gi://` resources.
 - `references/sequence-acquisition.md` — Ensembl fetch calls and the
-  expression-window (9,198 bp, TSS-centred) math.
+  expression-window (9,198 bp, TSS-centred) math, including `tss_index`.

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -325,7 +325,9 @@ keyed on the sibling `code`, but a validation failure currently arrives as a bar
 FastAPI error *array* (`[{loc, msg, type}, …]`) rather than the `{errors: […]}`
 object the schema declares — read it defensively and keep control flow off it.
 
-`error.request_id` is always populated and mirrors the `X-Request-Id` header.
+`error.request_id` mirrors the `X-Request-Id` header. The header is set on every
+response; the body field is not — `413 sync_too_large` omits it — so fall back to
+the header.
 Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
 `RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
 

--- a/skills/genomic-intelligence/SKILL.md
+++ b/skills/genomic-intelligence/SKILL.md
@@ -32,18 +32,19 @@ Use GI when the user has DNA and wants a model prediction:
 Not for local alignment, variant calling, or file I/O — use a local tool
 (BioPython, bcftools) for those. GI is for **model inference from sequence**.
 
-> For research and development use, **not clinical or diagnostic decisions**.
+> Research and development use. Not for clinical or diagnostic decisions.
 
 ## Two ways to call GI
 
-### Hosted MCP server (best for AI agents — keyless)
+### Hosted MCP server (keyless; preferred on MCP hosts)
 
 GI hosts an MCP server at `https://mcp.genomicintelligence.ai/mcp` (Streamable
 HTTP). When your agent host supports MCP, prefer it: it works **keyless** against
-a capped public demo quota (zero setup), and an optional `gi_` bearer key raises
-the quota. It exposes acquisition tools that return a **sequence handle**
-(`sequence_ref`) and `predict_*` tools that take that handle — so large sequences
-never bloat the context. See [MCP workflow](#mcp-workflow-handle-based) and
+a rate- and concurrency-limited public demo tier, and an optional `gi_` bearer
+key raises those limits.
+It exposes acquisition tools that return a **sequence handle** (`sequence_ref`)
+and `predict_*` tools that take that handle, so large sequences stay out of the
+context. See [MCP workflow](#mcp-workflow-handle-based) and
 `references/mcp.md`.
 
 ### REST API (universal)
@@ -93,7 +94,7 @@ options?}`, returning a `{data, meta}` envelope. What differs per task:
 **The minimum is admission control, not regime.** A request above the floor but
 shorter than the selected model's `bio_spec.context_window_bp` is *accepted and
 scored* — against a window padded out to the context window. Enhancer is the
-sharp case: the bound is 50 bp (DeepSTARR's gate) but the context window is
+sharp case: the floor is 50 bp while the context window is
 249 bp, so 50–248 bp is scored mostly on padding. Compare your length against
 `context_window_bp` from `GET /v1/tasks/{task}/models` to know whether the model
 saw real sequence. Longer-than-context input is fine — the scanner steps a
@@ -118,7 +119,7 @@ never ignored:
 | expression | `description` — **required**, and the only key |
 
 `Prefer: respond-async` is a declared header on **all six** predict operations
-and on the composite, not just `annotation` — see [Async](#async-any-task-annotation-always).
+and on the composite, not just `annotation` — see [Async](#async-any-task).
 
 **Omit `model` and the API uses the task's default** — that is the recommended
 call. Default model IDs are intentionally **not** documented here: defaults
@@ -147,7 +148,7 @@ or query parameter:
   is required, and is the **only** key `expression` accepts inside `options`.
   Unknown top-level body fields are rejected too.
 
-> Gotcha: the legal `tss_index` range is wide, so an offset that is merely
+> Note: the legal `tss_index` range is wide, so an offset that is merely
 > *wrong* (counted over raw FASTA characters including newlines, or relative to
 > a locus start rather than the submitted slice) does not error — it returns a
 > confident `200` for the wrong window. Assert on
@@ -178,7 +179,7 @@ You rarely start from a raw 9,198 bp string. Acquire sequence first:
   for REST. (`load_local_fasta` exists only in local deployments, not on the
   hosted server.)
 - **A demo sequence** → MCP `load_demo_sequence(name=...)` returns a ready handle
-  (great for a keyless smoke test); `name` is required.
+  for a keyless smoke test; `name` is required.
 
 See `references/sequence-acquisition.md` for the exact Ensembl calls and the
 expression-window math.
@@ -223,14 +224,14 @@ out = predict("expression", locus_seq, "HBB",
 print(out["meta"]["task_specific_counts"]["scored_window"])   # confirm the window scored
 ```
 
-### Async (any task; annotation always)
+### Async (any task)
 
 `Prefer: respond-async` is a declared header parameter on all six predict
 operations and on the composite. A `202` carries the same `{data, meta}` envelope
 as a sync `200`, with `data = {job_id, status: "accepted", links}`; the job id is
 also in the `Content-Location` and `X-Job-Id` response headers. Async is
 JSON-only — combining it with a text `format` is rejected. `annotation` is the
-task that needs it:
+task that most often needs it:
 
 ```python
 import time
@@ -257,7 +258,7 @@ the context:
 
 ```
 # 1. Acquire a sequence handle (each returns a sequence_ref):
-load_demo_sequence(name="promoter_tp53")  # keyless smoke test; `name` is REQUIRED
+load_demo_sequence(name="promoter_tp53")  # keyless smoke test; name is required
 fetch_ensembl_sequence(gene="TP53")       # gene symbol or Ensembl ID -> handle
 fetch_region(region="chr11:5,225,000-5,235,000")   # coordinates -> handle
 fetch_gene_for_expression(gene="HBB")     # TSS-centred 9,198 bp handle for expression
@@ -329,11 +330,11 @@ response; success envelopes carry `meta.request_id`.
 Every response carries `RateLimit-Limit`, `RateLimit-Remaining`,
 `RateLimit-Reset`, `RateLimit-Policy`; a `429` adds `Retry-After`.
 
-> Schema-version note: this describes gpu_service `2026.08.19.5`, live on
-> `api.genomicintelligence.ai` — the six literal operations, the typed `options`,
-> the per-task floors, the published composite, the `Prefer` parameter, the `code`
-> enum and the `bio_spec` fields are all present. Check `info.version` in
-> `/v1/openapi.json` if a detail here does not match.
+> The Genomic Intelligence API publishes the six literal predict operations, the
+> typed `options` objects, the per-task floors, the composite workflow, the
+> `Prefer` parameter, the `code` enum and the `bio_spec` fields described above.
+> The served schema at <https://api.genomicintelligence.ai/v1/openapi.json> is the
+> authority; read it if a detail here does not match.
 
 ## Reference files
 

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -35,8 +35,9 @@ Request body: `{sequence, sequence_name, model?, options?}`. `options` is
 task-specific — most notably `options.description` (required for `expression`).
 
 Success is a `{data, meta}` envelope; `data` is task-specific (see `tasks.md`),
-`meta` carries model + request info. Errors use a `{error}` envelope — see
-`errors.md`.
+`meta` carries model + request info. Errors use an `{error}` envelope carrying
+`code`, `message`, `status` and `request_id`; the most common is `422`
+`validation_failed` (wrong sequence length).
 
 ## Partner tiers
 

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -1,0 +1,44 @@
+# REST API & Authentication
+
+Base URL: `https://api.genomicintelligence.ai` (override with `GI_BASE_URL` for
+staging). Live contract: <https://api.genomicintelligence.ai/v1/openapi.json>.
+
+## Authentication
+
+Every `/v1/*` REST call needs a partner bearer key, sent as
+`Authorization: Bearer <key>`. Public routes needing no key: `/health`, `/docs`,
+`/redoc`, `/v1/openapi.json`.
+
+```bash
+export GI_API_KEY="gi_yourkeyhere"
+```
+
+Keys begin with `gi_`. Request one at contact@genomicintelligence.ai. Read the
+key from the environment (or a `.env` via `python-dotenv`); never hardcode or
+commit it.
+
+> The hosted **MCP** server (`mcp.genomicintelligence.ai/mcp`) is different: it
+> runs **keyless** against a capped public demo quota, with the key optional for
+> a higher quota. Only the **REST** path strictly requires a key. See `mcp.md`.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/v1/tasks/{task}/predict` | Run a task (sync, or async for `annotation` with `Prefer: respond-async`) |
+| GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running → 200 terminal) |
+| GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
+
+## Request / response
+
+Request body: `{sequence, sequence_name, model?, options?}`. `options` is
+task-specific — most notably `options.description` (required for `expression`).
+
+Success is a `{data, meta}` envelope; `data` is task-specific (see `tasks.md`),
+`meta` carries model + request info. Errors use a `{error}` envelope — see
+`errors.md`.
+
+## Partner tiers
+
+Keys are scoped to a tier with concurrency and per-minute caps. A `429` means a
+cap was hit — back off and retry, or ask GI to raise the tier.

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -23,25 +23,68 @@ commit it.
 
 ## Endpoints
 
+Eleven operations are published. The six predict paths are **literal, one per
+task** — the templated `/v1/tasks/{task}/predict` is no longer in the document
+(the URLs are unchanged, so nothing a client builds needs to change).
+
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/v1/tasks/{task}/predict` | Run a task (sync, or async for `annotation` with `Prefer: respond-async`). `task` ∈ promoter, splice, enhancer, chromatin, annotation |
-| POST | `/v1/tasks/expression/predict` | Expression — same URL shape, but its own published operation and its own (stricter) request schema |
+| POST | `/v1/tasks/promoter/predict` | `PromoterPredictRequest` |
+| POST | `/v1/tasks/splice/predict` | `SplicePredictRequest` |
+| POST | `/v1/tasks/enhancer/predict` | `EnhancerPredictRequest` |
+| POST | `/v1/tasks/chromatin/predict` | `ChromatinPredictRequest` |
+| POST | `/v1/tasks/annotation/predict` | `AnnotationPredictRequest` |
+| POST | `/v1/tasks/expression/predict` | `ExpressionPredictRequest` (also requires `options`) |
+| POST | `/v1/workflows/find-genes-and-predict-expression` | Composite: find genes, predict each one's expression |
+| GET | `/v1/tasks/jobs` | List async jobs |
 | GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running → 200 terminal) |
 | GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
+| GET | `/health` | Public liveness |
+
+`Prefer: respond-async` is a declared header parameter on all six predict
+operations and on the composite. An unrecognised task segment is
+`404 not_found` (`"Unknown task: bogus"`), **not** a `422`.
 
 ## Request / response
 
-Request body: `{sequence, sequence_name, model?, options?}`. `options` is
-task-specific. **`expression` differs**: its body is
-`{sequence, options, tss_index?, sequence_name?, model?}`, is closed to unknown
-fields, requires `options.description` (the only key it accepts), and requires
-`tss_index` unless `sequence` is exactly 9,198 bp. See `tasks.md#expression`.
+Request body: `{sequence, sequence_name?, model?, options?}` — but there is no
+longer a shared `PredictRequest`. Each task has its own request model with its own
+`minLength` (promoter 300, splice 100, enhancer 50, chromatin 200, annotation
+1,000, expression 9,198, composite 1,000; `maxLength` 500,000 for all), and every
+one is `additionalProperties: false`. `options` is likewise typed and closed per
+task, so an unknown key is `422 validation_failed` with `type: "extra_forbidden"`
+at `loc ["body","options","<key>"]`.
+
+**`expression` differs further**: its body is
+`{sequence, options, tss_index?, sequence_name?, model?}`, `options` is required
+(`ExpressionOptions.required = ["description"]`, the only key it accepts), and
+`tss_index` is required unless `sequence` is exactly 9,198 bp. See
+`tasks.md#expression`.
 
 Success is a `{data, meta}` envelope; `data` is task-specific (see `tasks.md`),
-`meta` carries model + request info. Errors use an `{error}` envelope carrying
-`code`, `message`, `status` and `request_id`; the most common is `422`
-`validation_failed` (wrong sequence length).
+`meta` carries model + request info. **Exception:** `GET /v1/tasks/{task}/models`
+is *not* enveloped — it returns a flat
+`{task, default_model, models: [{id, name, description, is_default, bio_spec}]}`.
+
+Errors use an `{error}` envelope carrying `code`, `message`, `request_id` and an
+optional `details`; the most common is `422 validation_failed` (wrong sequence
+length — under the floor *or* over 500,000 bp; over-length is not a `413`).
+
+## `bio_spec` (from `GET /v1/tasks/{task}/models`)
+
+- `request_max_bp` — the enforced ceiling: 500,000 for every model.
+- `context_window_bp` — the model's own sliding window; `null` for annotation and
+  expression. Live: promoter `g0-promoter-2000bp` 2,000 (300 bp promoter models
+  300), splice 15,000, enhancer 249, chromatin 1,000. Compare your sequence length
+  against this to know whether the model scored real sequence or padding.
+- `trained_window_bp` — fixed receptive field; 9,198 for `g0-expression`, `null`
+  for sliding-window models.
+- `max_seq_length_bp` — legacy and ambiguous: 500,000 everywhere **except**
+  `g0-expression`, where it is 9,198 (the trained window, not a cap). Prefer
+  `request_max_bp`.
+
+There is no `strand_sensitive` flag. The splice model is strand-specific in
+practice — feed transcript orientation.
 
 ## Partner tiers
 

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -25,14 +25,18 @@ commit it.
 
 | Method | Path | Purpose |
 |---|---|---|
-| POST | `/v1/tasks/{task}/predict` | Run a task (sync, or async for `annotation` with `Prefer: respond-async`) |
+| POST | `/v1/tasks/{task}/predict` | Run a task (sync, or async for `annotation` with `Prefer: respond-async`). `task` ∈ promoter, splice, enhancer, chromatin, annotation |
+| POST | `/v1/tasks/expression/predict` | Expression — same URL shape, but its own published operation and its own (stricter) request schema |
 | GET | `/v1/tasks/jobs/{job_id}` | Poll an async job (202 running → 200 terminal) |
 | GET | `/v1/tasks/{task}/models` | List available model IDs for a task |
 
 ## Request / response
 
 Request body: `{sequence, sequence_name, model?, options?}`. `options` is
-task-specific — most notably `options.description` (required for `expression`).
+task-specific. **`expression` differs**: its body is
+`{sequence, options, tss_index?, sequence_name?, model?}`, is closed to unknown
+fields, requires `options.description` (the only key it accepts), and requires
+`tss_index` unless `sequence` is exactly 9,198 bp. See `tasks.md#expression`.
 
 Success is a `{data, meta}` envelope; `data` is task-specific (see `tasks.md`),
 `meta` carries model + request info. Errors use an `{error}` envelope carrying

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -18,8 +18,9 @@ key from the environment (or a `.env` via `python-dotenv`); never hardcode or
 commit it.
 
 > The hosted **MCP** server (`mcp.genomicintelligence.ai/mcp`) is different: it
-> runs **keyless** against a capped public demo quota, with the key optional for
-> a higher quota. Only the **REST** path strictly requires a key. See `mcp.md`.
+> runs **keyless** against a rate- and concurrency-limited public demo tier, with
+> the key optional for higher limits. Only the **REST** path strictly requires a
+> key. See `mcp.md`.
 
 ## Endpoints
 
@@ -74,16 +75,15 @@ length — under the floor *or* over 500,000 bp; over-length is not a `413`).
 
 - `request_max_bp` — the enforced ceiling: 500,000 for every model.
 - `context_window_bp` — the model's own sliding window; `null` for annotation and
-  expression. Live: promoter `g0-promoter-2000bp` 2,000 (300 bp promoter models
-  300), splice 15,000, enhancer 249, chromatin 1,000. Compare your sequence length
-  against this to know whether the model scored real sequence or padding.
-- `trained_window_bp` — fixed receptive field; 9,198 for `g0-expression`, `null`
-  for sliding-window models.
-- The legacy `max_seq_length_bp` was retired from `bio_spec` in gpu_service
-  `2026.08.19.5` and is absent from the live response. It was ambiguous — it read
-  9,198 for `g0-expression`, the trained window rather than a request cap, so
-  gating on it wrongly rejected the 9,198–500,000 bp range expression accepts.
-  Use `request_max_bp`.
+  expression. Promoter 2,000 (the 300 bp promoter models 300), splice 15,000,
+  enhancer 249, chromatin 1,000. Compare your sequence length against this to
+  know whether the model scored real sequence or padding.
+- `trained_window_bp` — fixed receptive field; 9,198 for the expression model,
+  `null` for sliding-window models.
+- The legacy `max_seq_length_bp` is not part of `bio_spec` and is absent from the
+  response. It was ambiguous — it read 9,198 for the expression model, the trained
+  window rather than a request cap, so gating on it wrongly rejected the
+  9,198–500,000 bp range expression accepts. Use `request_max_bp`.
 
 There is no `strand_sensitive` flag. The splice model is strand-specific in
 practice — feed transcript orientation.

--- a/skills/genomic-intelligence/references/api-and-auth.md
+++ b/skills/genomic-intelligence/references/api-and-auth.md
@@ -79,9 +79,11 @@ length — under the floor *or* over 500,000 bp; over-length is not a `413`).
   against this to know whether the model scored real sequence or padding.
 - `trained_window_bp` — fixed receptive field; 9,198 for `g0-expression`, `null`
   for sliding-window models.
-- `max_seq_length_bp` — legacy and ambiguous: 500,000 everywhere **except**
-  `g0-expression`, where it is 9,198 (the trained window, not a cap). Prefer
-  `request_max_bp`.
+- The legacy `max_seq_length_bp` was retired from `bio_spec` in gpu_service
+  `2026.08.19.5` and is absent from the live response. It was ambiguous — it read
+  9,198 for `g0-expression`, the trained window rather than a request cap, so
+  gating on it wrongly rejected the 9,198–500,000 bp range expression accepts.
+  Use `request_max_bp`.
 
 There is no `strand_sensitive` flag. The splice model is strand-specific in
 practice — feed transcript orientation.

--- a/skills/genomic-intelligence/references/mcp.md
+++ b/skills/genomic-intelligence/references/mcp.md
@@ -6,35 +6,64 @@ GI hosts a Model Context Protocol server (Streamable HTTP) at:
 https://mcp.genomicintelligence.ai/mcp
 ```
 
-It works **keyless** against a capped public demo quota — no setup. An optional
-`gi_` bearer key (`GI_API_KEY`) raises the quota. Prefer MCP on agent hosts that
-support it: the tools mirror the six tasks with agent-friendly, handle-based
-schemas so large sequences never enter the context.
+It works **keyless** against a capped public demo quota, with no setup. An
+optional `gi_` bearer key (`GI_API_KEY`) raises the quota. Prefer MCP on agent
+hosts that support it: the tools use agent-friendly, handle-based schemas so large
+sequences never enter the context.
+
+The hosted server exposes **15 tools**. Verify with `tools/list` rather than
+assuming; the list below is a point-in-time snapshot.
 
 ## The handle-based flow
 
-Acquire a **sequence handle** (`sequence_ref`), then predict against it:
+Acquire a **sequence handle** (`sequence_ref`), then predict against it.
 
-1. **Acquire** — any of these return a `sequence_ref`:
-   - `load_demo_sequence()` — a ready demo handle (keyless smoke test)
-   - `fetch_ensembl_sequence(region=...)` / `fetch_region(...)` — reference
-     sequence for a gene or region (public Ensembl)
-   - `fetch_gene_for_expression(gene=...)` — a **TSS-centred 9,198 bp** handle
-     for `expression` (does the centring for you)
-   - `find_genes(region=...)` — genes in a region
-   - `load_local_fasta(path=...)` / `store_inline_sequence(sequence=...)` — from
-     a local FASTA or an inline string
-2. **Predict** — pass the handle:
-   - `predict_promoter`, `predict_splice`, `predict_enhancer`,
-     `predict_chromatin`, `predict_expression(..., description=...)`
-3. **Async** — `annotation` submits a job; poll `get_job(job_id)` (and
-   `list_jobs`) until terminal.
+### 1. Acquire (each returns a handle)
 
-## Discovery & composite
+| Tool | Required | Notes |
+|---|---|---|
+| `fetch_ensembl_sequence` | `gene` | Gene **symbol or Ensembl ID** (e.g. `"TP53"`). Also `species`, `flank_bp`. Not for coordinates. |
+| `fetch_region` | `region` | Coordinate range, e.g. `"chr8:127,680,000-127,800,000"`. Also `species`, `strand`, `flank_bp`. Plus strand by default, which is what gene finding expects. |
+| `fetch_gene_for_expression` | `gene` | Builds the **TSS-centred 9,198 bp** window `expression` needs. Also `species`. |
+| `load_demo_sequence` | `name` | **`name` is required.** Valid names: `promoter_tp53`, `splice_hbb`, `enhancer_eve`, `chromatin_active_promoter_chr19`, `expression_hbb_k562`, `annotation_hbb_chr11`. |
+| `store_inline_sequence` | `sequence` | Store an inline string; optional `name`. |
 
-- `list_models(task)` — the model registry for a task (don't invent IDs).
-- `find_genes_and_predict_expression(region=..., description=...)` — the
-  composite: find genes in a region, predict each one's expression.
+There is **no `load_local_fasta` on the hosted server** — it only exists in local
+deployments. Over REST, read the file yourself.
+
+### 2. Predict (pass the handle)
+
+`predict_promoter`, `predict_splice`, `predict_enhancer`, `predict_chromatin`,
+`predict_expression`. Each takes `sequence_ref` **or** `sequence` (mutually
+exclusive), plus optional `model` and `sequence_name`.
+
+`predict_expression` additionally needs `description` (cell type / assay, e.g.
+`"K562 cells"`).
+
+### 3. Gene finding (the annotation task on MCP)
+
+**There is no `predict_annotation` tool.** The annotation task is surfaced as
+**`find_genes`**, which takes `sequence_ref` or `sequence` — **not** a `region`.
+Acquire a region handle with `fetch_region` first, then pass the handle.
+
+`find_genes` runs async internally (~8-25 s). With `wait=True` (the default) it
+blocks and returns the result directly, never a job id. With `wait=False` it
+returns `{data: {job_id, status}}` to poll with `get_job(job_id)`.
+
+## Composite
+
+`find_genes_and_predict_expression` takes `sequence_ref` or `sequence` plus a
+**required** `description`. It has **no `region` parameter** — acquire a handle
+with `fetch_region` first. It finds genes in the sequence, then predicts
+expression off each discovered TSS. Use it whenever you want expression for a
+whole region: `predict_expression` cannot run on one, because it needs a single
+per-gene 9,198 bp window.
+
+## Jobs and discovery
+
+- `get_job(job_id)` (required `job_id`) and `list_jobs` — poll detached work.
+- `list_models(task)` — the model registry for a task. Do not invent model IDs,
+  and do not hardcode a default; omit `model` and the server resolves it.
 
 ## Resources
 
@@ -44,5 +73,22 @@ bounds.
 
 ## Small sequences
 
-Small sequences may be passed inline via a `sequence` argument on the
-`predict_*` tools, but the handle flow above is preferred to keep context small.
+Small sequences may be passed inline via `sequence` on the `predict_*` tools, but
+the handle flow above is preferred to keep context small.
+
+## Worked example
+
+```
+# region -> handle -> genes -> expression per gene
+h = fetch_region(region="chr11:5,225,000-5,235,000")
+find_genes(sequence_ref=h.ref)
+find_genes_and_predict_expression(sequence_ref=h.ref, description="K562 cells")
+
+# gene -> handle -> promoter
+g = fetch_ensembl_sequence(gene="TP53")
+predict_promoter(sequence_ref=g.ref)
+
+# keyless smoke test
+d = load_demo_sequence(name="promoter_tp53")
+predict_promoter(sequence_ref=d.ref)
+```

--- a/skills/genomic-intelligence/references/mcp.md
+++ b/skills/genomic-intelligence/references/mcp.md
@@ -1,0 +1,48 @@
+# Hosted MCP Server
+
+GI hosts a Model Context Protocol server (Streamable HTTP) at:
+
+```
+https://mcp.genomicintelligence.ai/mcp
+```
+
+It works **keyless** against a capped public demo quota — no setup. An optional
+`gi_` bearer key (`GI_API_KEY`) raises the quota. Prefer MCP on agent hosts that
+support it: the tools mirror the six tasks with agent-friendly, handle-based
+schemas so large sequences never enter the context.
+
+## The handle-based flow
+
+Acquire a **sequence handle** (`sequence_ref`), then predict against it:
+
+1. **Acquire** — any of these return a `sequence_ref`:
+   - `load_demo_sequence()` — a ready demo handle (keyless smoke test)
+   - `fetch_ensembl_sequence(region=...)` / `fetch_region(...)` — reference
+     sequence for a gene or region (public Ensembl)
+   - `fetch_gene_for_expression(gene=...)` — a **TSS-centred 9,198 bp** handle
+     for `expression` (does the centring for you)
+   - `find_genes(region=...)` — genes in a region
+   - `load_local_fasta(path=...)` / `store_inline_sequence(sequence=...)` — from
+     a local FASTA or an inline string
+2. **Predict** — pass the handle:
+   - `predict_promoter`, `predict_splice`, `predict_enhancer`,
+     `predict_chromatin`, `predict_expression(..., description=...)`
+3. **Async** — `annotation` submits a job; poll `get_job(job_id)` (and
+   `list_jobs`) until terminal.
+
+## Discovery & composite
+
+- `list_models(task)` — the model registry for a task (don't invent IDs).
+- `find_genes_and_predict_expression(region=..., description=...)` — the
+  composite: find genes in a region, predict each one's expression.
+
+## Resources
+
+Reference context lives in MCP resources: `gi://models`, `gi://docs/tasks`,
+`gi://sequences`, `gi://account`. Read these instead of hardcoding model lists or
+bounds.
+
+## Small sequences
+
+Small sequences may be passed inline via a `sequence` argument on the
+`predict_*` tools, but the handle flow above is preferred to keep context small.

--- a/skills/genomic-intelligence/references/mcp.md
+++ b/skills/genomic-intelligence/references/mcp.md
@@ -6,8 +6,8 @@ GI hosts a Model Context Protocol server (Streamable HTTP) at:
 https://mcp.genomicintelligence.ai/mcp
 ```
 
-It works **keyless** against a capped public demo quota, with no setup. An
-optional `gi_` bearer key (`GI_API_KEY`) raises the quota. Prefer MCP on agent
+It works **keyless** against a rate- and concurrency-limited public demo tier,
+with no setup. An optional `gi_` bearer key (`GI_API_KEY`) raises those limits. Prefer MCP on agent
 hosts that support it: the tools use agent-friendly, handle-based schemas so large
 sequences never enter the context.
 

--- a/skills/genomic-intelligence/references/sequence-acquisition.md
+++ b/skills/genomic-intelligence/references/sequence-acquisition.md
@@ -1,0 +1,52 @@
+# Sequence Acquisition (Ensembl)
+
+Turn a **gene symbol** or a **genomic region** into reference sequence so users
+don't have to bring a FASTA. Ensembl REST (`rest.ensembl.org`) is **public — no
+key**; only the *prediction* step needs a key (and only over REST).
+
+On MCP, the acquisition tools (`fetch_ensembl_sequence`, `fetch_region`,
+`fetch_gene_for_expression`, `find_genes`) do this for you and return a handle.
+Over REST, query Ensembl yourself, then feed the sequence to `/v1/tasks/...`.
+
+## Modes
+
+- **Full gene body** (any task except expression) — resolve the gene, fetch its
+  sequence.
+- **Coordinate range** — fetch `/sequence/region/{species}/{region}`.
+- **Exact 9,198 bp TSS-centred window** (expression only) — see below.
+
+## TSS-centring (why expression is special)
+
+The expression model requires **exactly 9,198 bp centred on the transcription
+start site (TSS)**. You cannot reliably build this from gene-body coordinates:
+the annotated gene start/end can sit far from the real TSS (HBB's gene end is
+2,324 bp from its canonical TSS; ACTB's is 33,301 bp). Mis-centring tanks the
+prediction.
+
+The correct construction: resolve the gene's **canonical transcript** (Ensembl
+`expand=1`), take the TSS from it (transcript start on the + strand, end on the −
+strand), and take **4,599 bp upstream + 4,598 bp downstream on the gene's
+strand = 9,198 bp**; validate the length exactly. On MCP,
+`fetch_gene_for_expression(gene=...)` does all of this. Because it needs a
+transcript, it works from a **gene**, not a bare region.
+
+## Species & assembly
+
+- **Default: human, GRCh38.**
+- Non-human: use the Ensembl **production name** — lowercase, underscored:
+  `mus_musculus`, `drosophila_melanogaster`, `saccharomyces_cerevisiae`. `mouse`
+  / `Drosophila` will be rejected.
+- The **enhancer** default (DeepSTARR) is *Drosophila* — match species to model
+  (see `tasks.md`).
+
+## When to skip acquisition
+
+Supply sequence directly when it is **not** reference genome — variant-bearing,
+edited, synthetic, or from a non-Ensembl assembly. Acquisition only returns
+reference sequence for the requested coordinates.
+
+## Limits
+
+Bounded by the task's own cap (500,000 bp for most; exactly 9,198 bp for
+expression). Ensembl enforces its own per-request size limits; fetch very large
+ranges in pieces.

--- a/skills/genomic-intelligence/references/sequence-acquisition.md
+++ b/skills/genomic-intelligence/references/sequence-acquisition.md
@@ -59,6 +59,10 @@ reference sequence for the requested coordinates.
 
 ## Limits
 
-Bounded by the task's own cap (500,000 bp for every task; expression additionally
-has a 9,198 bp **floor**). Ensembl enforces its own per-request size limits; fetch very large
+Bounded by the task's own cap (500,000 bp for every task) and its **floor**:
+promoter 300, splice 100, enhancer 50, chromatin 200, annotation 1,000,
+expression 9,198 bp. Clearing the floor only gets the request accepted — fetch at
+least the model's `context_window_bp` (promoter 2,000, splice 15,000, enhancer
+249, chromatin 1,000) if you want the score to reflect real sequence rather than
+padding. Ensembl enforces its own per-request size limits; fetch very large
 ranges in pieces.

--- a/skills/genomic-intelligence/references/sequence-acquisition.md
+++ b/skills/genomic-intelligence/references/sequence-acquisition.md
@@ -13,12 +13,18 @@ Over REST, query Ensembl yourself, then feed the sequence to `/v1/tasks/...`.
 - **Full gene body** (any task except expression) — resolve the gene, fetch its
   sequence.
 - **Coordinate range** — fetch `/sequence/region/{species}/{region}`.
-- **Exact 9,198 bp TSS-centred window** (expression only) — see below.
+- **9,198 bp TSS-centred window, or a wider locus + a `tss_index`** (expression
+  only) — see below.
 
 ## TSS-centring (why expression is special)
 
-The expression model requires **exactly 9,198 bp centred on the transcription
-start site (TSS)**. You cannot reliably build this from gene-body coordinates:
+The expression model always scores **exactly 9,198 bp centred on the
+transcription start site (TSS)**. You can either hand it a pre-cut 9,198 bp
+window, or hand it up to 500,000 bp plus `tss_index` — the 0-based TSS offset
+into the whitespace-stripped sequence — and let the server slice
+`sequence[tss_index-4599 : tss_index+4599]`. Either way you must know where the
+TSS is; the endpoint never discovers it, never pads, and never
+reverse-complements. You cannot reliably build this from gene-body coordinates:
 the annotated gene start/end can sit far from the real TSS (HBB's gene end is
 2,324 bp from its canonical TSS; ACTB's is 33,301 bp). Mis-centring tanks the
 prediction.
@@ -29,6 +35,12 @@ strand), and take **4,599 bp upstream + 4,598 bp downstream on the gene's
 strand = 9,198 bp**; validate the length exactly. On MCP,
 `fetch_gene_for_expression(gene=...)` does all of this. Because it needs a
 transcript, it works from a **gene**, not a bare region.
+
+If instead you submit a wider locus with `tss_index`, the offset must be counted
+on the **stripped nucleotide string** (no newlines, no FASTA header) and satisfy
+`4599 ≤ tss_index ≤ len(sequence) − 4599`. An offset that is out of range 422s;
+one that is merely *wrong* but in range silently scores the wrong window, so
+check `meta.task_specific_counts.scored_window` on the response.
 
 ## Species & assembly
 
@@ -47,6 +59,6 @@ reference sequence for the requested coordinates.
 
 ## Limits
 
-Bounded by the task's own cap (500,000 bp for most; exactly 9,198 bp for
-expression). Ensembl enforces its own per-request size limits; fetch very large
+Bounded by the task's own cap (500,000 bp for every task; expression additionally
+has a 9,198 bp **floor**). Ensembl enforces its own per-request size limits; fetch very large
 ranges in pieces.

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -1,0 +1,72 @@
+# Tasks Reference
+
+Six DNA-sequence tasks, one shared REST shape: `POST /v1/tasks/{task}/predict`
+with body `{sequence, sequence_name, model?, options?}`, returning a
+`{data, meta}` envelope. On MCP, the equivalent is `predict_<task>(sequence_ref, ...)`.
+
+**Omit `model` to get the task's default** — the API resolves it server-side
+(`model` is optional: *"If omitted, the task's default model is used."*). Default
+model **IDs are deliberately not listed here**: defaults change and old IDs are
+retired, so a hardcoded ID is a future hard failure. Discover them at call time
+with `GET /v1/tasks/{task}/models` (REST) or `list_models(task)` (MCP), and
+**never invent one**.
+
+Source of truth for bounds: the live OpenAPI at
+<https://api.genomicintelligence.ai/v1/openapi.json>.
+
+| Task | Mode | Length | Default architecture |
+|---|---|---|---|
+| promoter | sync | 1–500,000 bp | sliding-window; human/mammalian |
+| splice | sync | 1–500,000 bp | BigBird (long-context) |
+| enhancer | sync | 1–500,000 bp | DeepSTARR — ***Drosophila*** |
+| chromatin | sync | 1–500,000 bp | DeepSEA — hundreds of tracks |
+| expression | sync | **exactly 9,198 bp** | log(TPM+1) |
+| annotation | **async** | 1–500,000 bp | de-novo transcripts |
+
+## promoter
+Promoter regions over a sliding window. `data.summary` reports
+`promoter_windows` / `total_windows`; `data.regions` lists windows with `name`,
+`start`, `end`, `score`, `strand`. Non-human models exist (Drosophila, yeast,
+Arabidopsis) — pass `model`. Default targets human/mammalian sequence.
+
+## splice
+Splice **donor** and **acceptor** sites. `data.sites` lists each with `name`,
+`start`, `end`, `site_type` (donor/acceptor), `score`, `strand`. The default is a
+BigBird long-context model.
+
+## enhancer
+Enhancer activity. The default (DeepSTARR) reports **developmental**
+and **housekeeping** scores — `summary.dev_score_max` / `summary.hk_score_max`
+per window. DeepSTARR is a *Drosophila* model — match the species to the model.
+
+## chromatin
+Chromatin state across a large panel of tracks (histone marks, DNase, ATAC, TF
+binding). The default (DeepSEA) covers hundreds of features.
+`summary.total_annotations` is the headline; the full per-track matrix is in
+`data`.
+
+## expression
+Expression as **log(TPM+1)** from a fixed window. Two enforced requirements:
+
+1. **Exactly 9,198 bp** — a window **centred on the TSS** (2 × 4,599). Other
+   lengths are rejected. Build it with the acquisition helpers
+   (`fetch_gene_for_expression` on MCP), not by hand — see
+   `sequence-acquisition.md`.
+2. **`options.description`** — a cell-type / assay string (e.g. `"K562 cells"`).
+   Required.
+
+Result: `data.prediction.expression_log_tpm` (and `expression_tpm`).
+
+## annotation
+De-novo gene / transcript structure — transcript intervals and strand, no
+reference annotation. **Async only** (see `errors.md`): submit with
+`Prefer: respond-async` → `job_id`; poll `GET /v1/tasks/jobs/{job_id}` until it
+returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
+`end`, `strand`, `score`, plus structure fields (`length`, `tss_position`,
+`polya_position`, `transcript_type`, `exons`, `introns`, `cds`).
+
+## Composite: find genes + predict expression
+"What genes are in this region, and how are they expressed?" — MCP
+`find_genes_and_predict_expression(region, description)` finds genes in a region
+and returns an expression prediction per gene. Over REST, discover genes then
+loop `expression` per gene (build each TSS-centred 9,198 bp window first).

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -48,7 +48,8 @@ binding). The default (DeepSEA) covers hundreds of features.
 ## expression
 Expression as **log(TPM+1)** from a fixed window. Two enforced requirements:
 
-1. **Exactly 9,198 bp** — a window **centred on the TSS** (2 × 4,599). Other
+1. **Exactly 9,198 bp** — a window **centred on the TSS** (4,599 upstream +
+   TSS + 4,598 downstream). Other
    lengths are rejected. Build it with the acquisition helpers
    (`fetch_gene_for_expression` on MCP), not by hand — see
    `sequence-acquisition.md`.
@@ -59,7 +60,7 @@ Result: `data.prediction.expression_log_tpm` (and `expression_tpm`).
 
 ## annotation
 De-novo gene / transcript structure — transcript intervals and strand, no
-reference annotation. **Async only** (see `errors.md`): submit with
+reference annotation. **Async only**: submit with
 `Prefer: respond-async` → `job_id`; poll `GET /v1/tasks/jobs/{job_id}` until it
 returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
 `end`, `strand`, `score`, plus structure fields (`length`, `tss_position`,
@@ -67,6 +68,8 @@ returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
 
 ## Composite: find genes + predict expression
 "What genes are in this region, and how are they expressed?" — MCP
-`find_genes_and_predict_expression(region, description)` finds genes in a region
+`find_genes_and_predict_expression(sequence_ref, description)` takes a **handle,
+not a region** (acquire one with `fetch_region` first); `description` is
+required. It finds genes in the sequence
 and returns an expression prediction per gene. Over REST, discover genes then
 loop `expression` per gene (build each TSS-centred 9,198 bp window first).

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -20,13 +20,13 @@ with `GET /v1/tasks/{task}/models` (REST) or `list_models(task)` (MCP), and
 Source of truth for bounds: the live OpenAPI at
 <https://api.genomicintelligence.ai/v1/openapi.json>.
 
-| Task | Mode | Accepted length | Model context window | Default architecture |
+| Task | Mode | Accepted length | `context_window_bp` | Default architecture |
 |---|---|---|---|---|
 | promoter | sync | 300–500,000 bp | 2,000 bp | sliding-window; human/mammalian |
 | splice | sync | 100–500,000 bp | 15,000 bp | BigBird (long-context) |
 | enhancer | sync | 50–500,000 bp | 249 bp | DeepSTARR — ***Drosophila*** |
 | chromatin | sync | 200–500,000 bp | 1,000 bp | DeepSEA — hundreds of tracks |
-| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | 9,198 bp (fixed) | log(TPM+1) |
+| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | n/a (`trained_window_bp` 9,198) | log(TPM+1) |
 | annotation | **async** | 1,000–500,000 bp | n/a | de-novo transcripts |
 
 The minimum is published as `minLength` on each task's request schema and enforced

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -20,14 +20,16 @@ with `GET /v1/tasks/{task}/models` (REST) or `list_models(task)` (MCP), and
 Source of truth for bounds: the live OpenAPI at
 <https://api.genomicintelligence.ai/v1/openapi.json>.
 
-| Task | Mode | Accepted length | `context_window_bp` | Default architecture |
+| Task | Recommended mode | Accepted length | `context_window_bp` | Default architecture |
 |---|---|---|---|---|
 | promoter | sync | 300–500,000 bp | 2,000 bp | sliding-window; human/mammalian |
 | splice | sync | 100–500,000 bp | 15,000 bp | BigBird (long-context) |
 | enhancer | sync | 50–500,000 bp | 249 bp | DeepSTARR — ***Drosophila*** |
 | chromatin | sync | 200–500,000 bp | 1,000 bp | DeepSEA — hundreds of tracks |
 | expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | n/a (`trained_window_bp` 9,198) | log(TPM+1) |
-| annotation | **async** | 1,000–500,000 bp | n/a | de-novo transcripts |
+| annotation | async | 1,000–500,000 bp | n/a | de-novo transcripts |
+
+`Recommended mode` is guidance, not a constraint — every task accepts both. Omit `Prefer` for a synchronous `200`; send `Prefer: respond-async` for a `202` plus `GET /v1/tasks/jobs/{job_id}`. Only the composite workflow enforces a mode, rejecting sync above 50,000 bp with `413 sync_too_large`.
 
 The minimum is published as `minLength` on each task's request schema and enforced
 before any model loads. There are **no per-model floors**: a task's floor is the

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -20,7 +20,7 @@ Source of truth for bounds: the live OpenAPI at
 | splice | sync | 1–500,000 bp | BigBird (long-context) |
 | enhancer | sync | 1–500,000 bp | DeepSTARR — ***Drosophila*** |
 | chromatin | sync | 1–500,000 bp | DeepSEA — hundreds of tracks |
-| expression | sync | **exactly 9,198 bp** | log(TPM+1) |
+| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | log(TPM+1) |
 | annotation | **async** | 1–500,000 bp | de-novo transcripts |
 
 ## promoter
@@ -46,17 +46,36 @@ binding). The default (DeepSEA) covers hundreds of features.
 `data`.
 
 ## expression
-Expression as **log(TPM+1)** from a fixed window. Two enforced requirements:
+Expression as **log(TPM+1)** from a fixed window. Since 2026-08-18 this task has
+its own published OpenAPI operation (`POST /v1/tasks/expression/predict`,
+schema `ExpressionPredictRequest`) rather than the generic
+`/v1/tasks/{task}/predict` body — codegen consumers must regenerate. Body:
+`{sequence, options, tss_index?, sequence_name?, model?}`, closed to unknown
+fields. Three enforced requirements, each a `422` when violated:
 
-1. **Exactly 9,198 bp** — a window **centred on the TSS** (4,599 upstream +
-   TSS + 4,598 downstream). Other
-   lengths are rejected. Build it with the acquisition helpers
-   (`fetch_gene_for_expression` on MCP), not by hand — see
-   `sequence-acquisition.md`.
-2. **`options.description`** — a cell-type / assay string (e.g. `"K562 cells"`).
-   Required.
+1. **9,198–500,000 bp.** The model scores exactly one 9,198 bp window
+   **centred on the TSS** — `sequence[tss_index-4599 : tss_index+4599]` — but
+   the endpoint accepts up to 500 kb and slices for you. Below 9,198 bp is
+   rejected; nothing is padded or truncated.
+2. **`tss_index`** — 0-based TSS offset into the **whitespace-stripped**
+   sequence. Required unless the sequence is exactly 9,198 bp (where it defaults
+   to 4,599, the only legal value). Bounds:
+   `4599 ≤ tss_index ≤ len(sequence) − 4599`. The server does not find the TSS
+   for you and does not reverse-complement — submit gene-sense.
+3. **`options.description`** — a cell-type / assay string (e.g. `"K562 cells"`).
+   Required, and the only key `options` accepts here.
+
+Whitespace is stripped before lengths and `tss_index` are interpreted, so a
+line-wrapped FASTA *body* can be pasted verbatim — but a `>` header line cannot
+(it fails the A/C/G/T/N alphabet check), and offsets must be counted on the
+stripped string, not on file characters.
 
 Result: `data.prediction.expression_log_tpm` (and `expression_tpm`).
+`meta.task_specific_counts` carries `tss_index` and `scored_window`
+(`[start, end]`, always 9,198 wide) — assert on it, because an in-range but
+wrong `tss_index` scores the wrong window with a `200`. `data.input` echoes
+`tss_index`, `scored_window`, and `submitted_sequence_length`; note
+`data.input.sequence_length` is the **scored** 9,198, not what you submitted.
 
 ## annotation
 De-novo gene / transcript structure — transcript intervals and strand, no
@@ -71,5 +90,7 @@ returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
 `find_genes_and_predict_expression(sequence_ref, description)` takes a **handle,
 not a region** (acquire one with `fetch_region` first); `description` is
 required. It finds genes in the sequence
-and returns an expression prediction per gene. Over REST, discover genes then
-loop `expression` per gene (build each TSS-centred 9,198 bp window first).
+and returns an expression prediction per gene. The composite does its own gene
+finding and windowing, so it has **no** 9,198 bp floor and takes **no**
+`tss_index`. Over REST, discover genes then loop `expression` per gene (build
+each TSS-centred 9,198 bp window, or pass the locus plus a `tss_index`).

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -1,8 +1,14 @@
 # Tasks Reference
 
-Six DNA-sequence tasks, one shared REST shape: `POST /v1/tasks/{task}/predict`
-with body `{sequence, sequence_name, model?, options?}`, returning a
-`{data, meta}` envelope. On MCP, the equivalent is `predict_<task>(sequence_ref, ...)`.
+Six DNA-sequence tasks, each its own published REST operation —
+`POST /v1/tasks/promoter/predict`, `/v1/tasks/splice/predict`,
+`/v1/tasks/enhancer/predict`, `/v1/tasks/chromatin/predict`,
+`/v1/tasks/annotation/predict`, `/v1/tasks/expression/predict` — with body
+`{sequence, sequence_name?, model?, options?}`, returning a `{data, meta}`
+envelope. The URLs are the same strings clients already send; what changed is that
+each has its own request schema, its own `minLength`, and its own closed `options`
+object (there is no shared `PredictRequest` any more). On MCP, the equivalent is
+`predict_<task>(sequence_ref, ...)`.
 
 **Omit `model` to get the task's default** — the API resolves it server-side
 (`model` is optional: *"If omitted, the task's default model is used."*). Default
@@ -14,14 +20,49 @@ with `GET /v1/tasks/{task}/models` (REST) or `list_models(task)` (MCP), and
 Source of truth for bounds: the live OpenAPI at
 <https://api.genomicintelligence.ai/v1/openapi.json>.
 
-| Task | Mode | Length | Default architecture |
-|---|---|---|---|
-| promoter | sync | 1–500,000 bp | sliding-window; human/mammalian |
-| splice | sync | 1–500,000 bp | BigBird (long-context) |
-| enhancer | sync | 1–500,000 bp | DeepSTARR — ***Drosophila*** |
-| chromatin | sync | 1–500,000 bp | DeepSEA — hundreds of tracks |
-| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | log(TPM+1) |
-| annotation | **async** | 1–500,000 bp | de-novo transcripts |
+| Task | Mode | Accepted length | Model context window | Default architecture |
+|---|---|---|---|---|
+| promoter | sync | 300–500,000 bp | 2,000 bp | sliding-window; human/mammalian |
+| splice | sync | 100–500,000 bp | 15,000 bp | BigBird (long-context) |
+| enhancer | sync | 50–500,000 bp | 249 bp | DeepSTARR — ***Drosophila*** |
+| chromatin | sync | 200–500,000 bp | 1,000 bp | DeepSEA — hundreds of tracks |
+| expression | sync | **9,198–500,000 bp** (scores one 9,198 bp window) | 9,198 bp (fixed) | log(TPM+1) |
+| annotation | **async** | 1,000–500,000 bp | n/a | de-novo transcripts |
+
+The minimum is published as `minLength` on each task's request schema and enforced
+before any model loads. There are **no per-model floors**: a task's floor is the
+strictest its models need, and every model stays listed and loadable.
+
+**Floor ≠ regime.** A request above the floor but shorter than the selected
+model's `bio_spec.context_window_bp` is accepted and scored — against a window
+padded out to the context window. Enhancer is the sharp case: the bound is 50 bp
+(DeepSTARR's admission gate; `dnabert-deepstarr` tolerates 16) while the context
+window is 249 bp, so 50–248 bp is scored mostly on padding. Compare your length
+against `context_window_bp` to know whether the model saw real sequence.
+Longer-than-context input is fine — the scanner steps a prediction window at a
+time and pads only the final partial window.
+
+Under the floor and over the cap are both `422 validation_failed` at
+`loc ["body","sequence"]`; over-length is **not** a `413`. All lengths are
+measured after whitespace is stripped.
+
+`options` is typed and closed (`additionalProperties: false`) per task — an
+unknown key is a hard `422` (`type: "extra_forbidden"`), never ignored:
+
+| Task | `options` keys |
+|---|---|
+| promoter | `threshold` (0–1, default 0.5) |
+| splice | `threshold` (0–1, default 0.5), `site_types` (subset of `["donor","acceptor"]`, default both) |
+| enhancer | *(none)* |
+| chromatin | `threshold` (0–1, default 0.5) |
+| annotation | `batch_size` (1–128, default 8), `shift_coordinates`, `reverse_complement` (default true) |
+| expression | `description` — **required**, and the only key |
+| composite | `description`, `annotation_model`, `expression_model`, `batch_size`, `shift_coordinates` |
+
+Per-task output `format` values (an unsupported one is `415 unsupported_format`,
+never a silent fallback to JSON; text formats are synchronous-only): promoter
+`json|bed|bedgraph`, splice `json|bed|gff3`, enhancer `json|bedgraph`, chromatin
+`json|bed`, annotation `json|bed|gff3`, expression JSON only.
 
 ## promoter
 Promoter regions over a sliding window. `data.summary` reports
@@ -46,10 +87,9 @@ binding). The default (DeepSEA) covers hundreds of features.
 `data`.
 
 ## expression
-Expression as **log(TPM+1)** from a fixed window. Since 2026-08-18 this task has
-its own published OpenAPI operation (`POST /v1/tasks/expression/predict`,
-schema `ExpressionPredictRequest`) rather than the generic
-`/v1/tasks/{task}/predict` body — codegen consumers must regenerate. Body:
+Expression as **log(TPM+1)** from a fixed window. Its operation is
+`POST /v1/tasks/expression/predict`, schema `ExpressionPredictRequest` — alone
+among the six it requires `options` as well as `sequence`. Body:
 `{sequence, options, tss_index?, sequence_name?, model?}`, closed to unknown
 fields. Three enforced requirements, each a `422` when violated:
 
@@ -77,9 +117,14 @@ wrong `tss_index` scores the wrong window with a `200`. `data.input` echoes
 `tss_index`, `scored_window`, and `submitted_sequence_length`; note
 `data.input.sequence_length` is the **scored** 9,198, not what you submitted.
 
+Both `tss_index` failures come from a `model_validator(mode="after")` and so
+report at `loc: ["body"]`, **never** `body.tss_index`. Match on
+`error.code == "validation_failed"` — never on `loc`.
+
 ## annotation
 De-novo gene / transcript structure — transcript intervals and strand, no
-reference annotation. **Async only**: submit with
+reference annotation. **Run it async** (`Prefer: respond-async` is available on
+every predict operation; annotation is the one that needs it): submit with
 `Prefer: respond-async` → `job_id`; poll `GET /v1/tasks/jobs/{job_id}` until it
 returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
 `end`, `strand`, `score`, plus structure fields (`length`, `tss_position`,
@@ -92,5 +137,24 @@ not a region** (acquire one with `fetch_region` first); `description` is
 required. It finds genes in the sequence
 and returns an expression prediction per gene. The composite does its own gene
 finding and windowing, so it has **no** 9,198 bp floor and takes **no**
-`tss_index`. Over REST, discover genes then loop `expression` per gene (build
-each TSS-centred 9,198 bp window, or pass the locus plus a `tss_index`).
+`tss_index`.
+
+Over REST it is a single published operation:
+`POST /v1/workflows/find-genes-and-predict-expression`, request
+`FindGenesAndPredictExpressionRequest` — `sequence` 1,000–500,000 bp and
+`options` both required, and `options.description` required too (enforced at
+runtime rather than marked `required` in `FindGenesAndPredictExpressionOptions`,
+so a missing or empty value is `422 validation_failed`, *"options.description is
+required (cell type / assay context)"*). Optional: `annotation_model`,
+`expression_model`, `batch_size` (1–128, default 8), `shift_coordinates`.
+
+It cuts a TSS-centred 9,198 bp window per discovered gene, padding with `N` up to
+half the window rather than dropping an edge gene — the direct expression route
+refuses to pad at all. `meta.task_specific_counts` =
+`{genes_found, genes_predicted, genes_skipped}` with
+`genes_predicted + genes_skipped == genes_found`; per-gene causes in
+`data.expression_predictions[].skip_reason`.
+
+Above **50,000 bp** it forces async: a synchronous request over that size is
+`413 sync_too_large` with `error.details = {sequence_length, threshold}`. Retry
+the same body with `Prefer: respond-async`.

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -77,6 +77,13 @@ Splice **donor** and **acceptor** sites. `data.sites` lists each with `name`,
 `start`, `end`, `site_type` (donor/acceptor), `score`, `strand`. The default is a
 BigBird long-context model.
 
+**`start`/`end` is a token span, not the junction base.** It bounds one
+variable-width tokenizer token — 4–10 bp across the sequences measured so far —
+reported with a `token_index`, and the exon/intron junction lies somewhere
+inside it. Do not derive a base position from the pair, and do not intersect it
+against reference annotation as though it were a boundary; the same span is what
+lands in GFF3 columns 4–5 of the `gff3` output.
+
 **Strand-specific — and the wrong strand fails silently.** Submit transcript
 orientation (reverse-complement minus-strand genes). A reverse-complemented
 sequence does *not* return zeros or an empty result: measured live, it returns

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -38,8 +38,8 @@ strictest its models need, and every model stays listed and loadable.
 **Floor ≠ regime.** A request above the floor but shorter than the selected
 model's `bio_spec.context_window_bp` is accepted and scored — against a window
 padded out to the context window. Enhancer is the sharp case: the bound is 50 bp
-(DeepSTARR's admission gate; `dnabert-deepstarr` tolerates 16) while the context
-window is 249 bp, so 50–248 bp is scored mostly on padding. Compare your length
+(the task's published `minLength`) while the context window is 249 bp, so
+50–248 bp is scored mostly on padding. Compare your length
 against `context_window_bp` to know whether the model saw real sequence.
 Longer-than-context input is fine — the scanner steps a prediction window at a
 time and pads only the final partial window.
@@ -119,15 +119,15 @@ wrong `tss_index` scores the wrong window with a `200`. `data.input` echoes
 `tss_index`, `scored_window`, and `submitted_sequence_length`; note
 `data.input.sequence_length` is the **scored** 9,198, not what you submitted.
 
-Both `tss_index` failures come from a `model_validator(mode="after")` and so
-report at `loc: ["body"]`, **never** `body.tss_index`. Match on
+Both `tss_index` failures come from a whole-model validator and so report at
+`loc: ["body"]`, **never** `body.tss_index`. Match on
 `error.code == "validation_failed"` — never on `loc`.
 
 ## annotation
 De-novo gene / transcript structure — transcript intervals and strand, no
 reference annotation. **Run it async** (`Prefer: respond-async` is available on
-every predict operation; annotation is the one that needs it): submit with
-`Prefer: respond-async` → `job_id`; poll `GET /v1/tasks/jobs/{job_id}` until it
+every predict operation; annotation is the one that most often needs it):
+submit with `Prefer: respond-async` → `job_id`; poll `GET /v1/tasks/jobs/{job_id}` until it
 returns `200`. `data.transcripts` lists each transcript with `name`, `start`,
 `end`, `strand`, `score`, plus structure fields (`length`, `tss_position`,
 `polya_position`, `transcript_type`, `exons`, `introns`, `cds`).

--- a/skills/genomic-intelligence/references/tasks.md
+++ b/skills/genomic-intelligence/references/tasks.md
@@ -77,6 +77,14 @@ Splice **donor** and **acceptor** sites. `data.sites` lists each with `name`,
 `start`, `end`, `site_type` (donor/acceptor), `score`, `strand`. The default is a
 BigBird long-context model.
 
+**Strand-specific — and the wrong strand fails silently.** Submit transcript
+orientation (reverse-complement minus-strand genes). A reverse-complemented
+sequence does *not* return zeros or an empty result: measured live, it returns
+plausible sites at different positions, often still at high confidence, and site
+counts can hold or collapse depending on the locus. **Neither the score nor the
+count tells you the orientation was wrong**, so there is no post-hoc check —
+get the orientation right on input.
+
 ## enhancer
 Enhancer activity. The default (DeepSTARR) reports **developmental**
 and **housekeeping** scores — `summary.dev_score_max` / `summary.hk_score_max`


### PR DESCRIPTION
## Add `genomic-intelligence` skill

Adds a skill wrapping Genomic Intelligence (GI), a set of hosted transformer DNA
language models that predict regulatory features, gene structure, and expression
directly from DNA sequence. No local GPU or model weights are needed; the skill is
a thin client over a hosted, versioned inference API.

### What it does

Give it a gene symbol, a genomic region, or a DNA/FASTA sequence and it returns
structured predictions across six tasks, plus a composite:

- `promoter`: promoter regions (sliding window)
- `splice`: donor/acceptor splice sites
- `enhancer`: developmental and housekeeping enhancer activity
- `chromatin`: chromatin state across hundreds of tracks
- `expression`: sequence to expression, log(TPM+1)
- `annotation`: de-novo gene/transcript annotation
- composite: find the genes in a region and predict each one's expression

### Shape

This mirrors the existing hosted-API skills (`alphafold-database`,
`chembl-database`, `pubchem-database`): a `SKILL.md` with `name` and `description`
frontmatter plus a `references/` directory, using inline `requests` with no
vendored client.

There are two ways to call GI. The REST `/v1` API needs a `GI_API_KEY` bearer. The
hosted MCP server at `https://mcp.genomicintelligence.ai/mcp` works keyless
against a public demo quota, with the key optional for a higher quota.

`references/` documents the tasks, the REST contract and auth, the MCP tool flow,
and Ensembl-based sequence acquisition, including the exact 9,198 bp TSS-centred
window the `expression` model requires.

### Registration

Appended `"./skills/genomic-intelligence"` to the `skills` array in
`openclaw.plugin.json`, in alphabetical position. Added a row to the README skills
table under Scientific Databases (Genomics & Variants) and bumped the Skills
Overview counts from 43 to 44 for that category and from 869 to 870 for the total.

### Validation

`python scripts/validate_skill.py skills/genomic-intelligence` reports "Skill is
valid!" and `python scripts/validate_skill.py openclaw.plugin.json` reports
"Manifest valid, found 870 skills". No secrets are committed; the key is read from
the `GI_API_KEY` environment variable.

The keyless MCP path was verified against the live endpoint: an anonymous
Streamable HTTP session with no `Authorization` header completes `initialize` and
returns a real `predict_promoter` result.

### Notes

For research and development use, not clinical or diagnostic decisions.

Docs: <https://docs.genomicintelligence.ai>
